### PR TITLE
Fix OS-specific code (Mac/UNIX overlap)

### DIFF
--- a/plugins-src/TWPythonPlugin/TWPythonPlugin.h
+++ b/plugins-src/TWPythonPlugin/TWPythonPlugin.h
@@ -22,7 +22,7 @@
 #ifndef TW_PYTHON_PLUGIN_H
 #define TW_PYTHON_PLUGIN_H
 
-#ifdef __APPLE__ // can't use Q_WS_MAC as it's not defined yet!
+#ifdef __APPLE__ // can't use Q_OS_DARWIN as it's not defined yet!
 #include <Python/Python.h>
 #else
 #include <Python.h>

--- a/src/CompletingEdit.cpp
+++ b/src/CompletingEdit.cpp
@@ -746,7 +746,7 @@ void CompletingEdit::handleCompletionShortcut(QKeyEvent *e)
 //   ctl/alt       : skip to next placeholder (alt on Mac, ctl elsewhere)
 //   ctl/alt-shift : skip to previous placeholder
 
-#if defined(Q_WS_MAC) || defined(Q_OS_MAC)
+#if defined(Q_OS_DARWIN)
 	if ((e->modifiers() & ~Qt::ShiftModifier) == Qt::AltModifier)
 #else
 	if ((e->modifiers() & ~Qt::ShiftModifier) == Qt::ControlModifier)

--- a/src/ConfigurableApp.h
+++ b/src/ConfigurableApp.h
@@ -25,7 +25,7 @@
 #include <QApplication>
 #include <QSettings>
 
-#if defined(Q_WS_MAC) || defined(Q_OS_MAC)
+#if defined(Q_OS_DARWIN)
 #define QSETTINGS_OBJECT(s) \
 			QSettings s(ConfigurableApp::instance()->getSettingsFormat(), QSettings::UserScope, \
 						ConfigurableApp::instance()->organizationDomain(), ConfigurableApp::instance()->applicationName())

--- a/src/HardWrapDialog.cpp
+++ b/src/HardWrapDialog.cpp
@@ -48,7 +48,7 @@ HardWrapDialog::init()
 	bool rewrapParagraphs = settings.value("hardWrapRewrap", false).toBool();
 	checkbox_rewrap->setChecked(rewrapParagraphs);
 
-#if defined(Q_WS_MAC) || defined(Q_OS_MAC)
+#if defined(Q_OS_DARWIN)
 	setWindowFlags(Qt::Sheet);
 #endif
 }

--- a/src/PDFDocks.cpp
+++ b/src/PDFDocks.cpp
@@ -241,7 +241,7 @@ PDFFontsDock::PDFFontsDock(PDFDocument *doc)
 	setObjectName("fonts");
 	setWindowTitle(getTitle());
 	table = new QTableWidget(this);
-#if defined(Q_WS_MAC) || defined(Q_OS_MAC) /* don't do this on windows, as the font ends up too small */
+#if defined(Q_OS_DARWIN) /* don't do this on windows, as the font ends up too small */
 	QFont f(table->font());
 	f.setPointSize(f.pointSize() - 2);
 	table->setFont(f);

--- a/src/PDFDocument.cpp
+++ b/src/PDFDocument.cpp
@@ -1210,7 +1210,7 @@ PDFDocument::init()
 	docList.append(this);
 
 	setupUi(this);
-#if defined(Q_WS_WIN) || defined(Q_OS_WIN)
+#if defined(Q_OS_WIN)
 	TWApp::instance()->createMessageTarget(this);
 #endif
 
@@ -1218,7 +1218,7 @@ PDFDocument::init()
 	setAttribute(Qt::WA_MacNoClickThrough, true);
 
 	QIcon winIcon;
-#if defined(Q_WS_X11) || defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
+#if defined(Q_OS_UNIX) && !defined(Q_OS_DARWIN)
 	// The Compiz window manager doesn't seem to support icons larger than
 	// 128x128, so we add a suitable one first
 	winIcon.addFile(":/images/images/TeXworks-doc-128.png");
@@ -1659,7 +1659,7 @@ void PDFDocument::goToSource()
 
 void PDFDocument::enablePageActions(int pageIndex)
 {
-//#ifndef Q_WS_MAC
+//#if !defined(Q_OS_DARWIN)
 // On Mac OS X, disabling these leads to a crash if we hit the end of document while auto-repeating a key
 // (seems like a Qt bug, but needs further investigation)
 // 2008-09-07: seems to no longer be a problem, probably thanks to Qt 4.4 update

--- a/src/PrefsDialog.cpp
+++ b/src/PrefsDialog.cpp
@@ -138,7 +138,7 @@ void PrefsDialog::addPath()
 								QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
 	// remove the trailing / (if any)
 	dir = QDir::fromNativeSeparators(dir);
-#if defined(Q_WS_WIN) || defined(Q_OS_WIN)
+#if defined(Q_OS_WIN)
 	if (dir.length() > 2)
 #else
 	if (dir.length() > 1)

--- a/src/ResourcesDialog.cpp
+++ b/src/ResourcesDialog.cpp
@@ -35,7 +35,7 @@ void ResourcesDialog::init()
 
 	setupUi(this);
 	
-#if defined(Q_WS_WIN) || defined(Q_OS_WIN)
+#if defined(Q_OS_WIN)
 	if(ConfigurableApp::instance()->getSettingsFormat() == QSettings::NativeFormat)
 		locationOfSettings->setText(tr("Registry (%1)").arg(s.fileName()));
 	else

--- a/src/TWApp.h
+++ b/src/TWApp.h
@@ -35,7 +35,7 @@
 #include "ConfigurableApp.h"
 #include "TWScriptAPI.h"
 
-#if defined(Q_WS_WIN) || defined(Q_OS_WIN)
+#if defined(Q_OS_WIN)
 #define PATH_LIST_SEP   ';'
 #define EXE             ".exe"
 #else
@@ -60,7 +60,7 @@ class QMenuBar;
 const int kStatusMessageDuration = 3000;
 const int kNewWindowOffset = 32;
 
-#if defined(Q_WS_WIN) || defined(Q_OS_WIN) // for communication with the original instance
+#if defined(Q_OS_WIN) // for communication with the original instance
 #if !defined(_WIN32_WINNT) || _WIN32_WINNT < 0x0500
 	#define _WIN32_WINNT			0x0500	// for HWND_MESSAGE
 #endif
@@ -118,7 +118,7 @@ public:
 	
 	void notifyDictionaryListChanged() const { emit dictionaryListChanged(); }
 
-#if defined(Q_WS_WIN) || defined(Q_OS_WIN)
+#if defined(Q_OS_WIN)
 	void createMessageTarget(QWidget* aWindow);
 	static QString GetWindowsVersionString();
 	static unsigned int GetWindowsVersion();
@@ -152,7 +152,7 @@ public:
 	Q_INVOKABLE bool hasGlobal(const QString& key) const { return m_globals.contains(key); }
 	Q_INVOKABLE QVariant getGlobal(const QString& key) const { return m_globals[key]; }
 	
-#if defined(Q_WS_MAC) || defined(Q_OS_MAC)
+#if defined(Q_OS_DARWIN)
 private:
 	// on the Mac only, we have a top-level app menu bar, including its own copy of the recent files menu
 	QMenuBar *menuBar;
@@ -267,7 +267,7 @@ private:
 	QHash<QString, QVariant> m_globals;
 	QList<QTextCodec*> customTextCodecs;
 	
-#if defined(Q_WS_WIN) || defined(Q_OS_WIN)
+#if defined(Q_OS_WIN)
 	HWND messageTargetWindow;
 #endif
 

--- a/src/TWScriptAPI.cpp
+++ b/src/TWScriptAPI.cpp
@@ -57,11 +57,11 @@ int TWScriptAPI::strlen(const QString& str) const
 
 QString TWScriptAPI::platform() const
 {
-#if defined(Q_WS_MAC) || defined(Q_OS_MAC)
+#if defined(Q_OS_DARWIN)
 	return QString("MacOSX");
-#elif defined(Q_WS_WIN) || defined(Q_OS_WIN)
+#elif defined(Q_OS_WIN)
 	return QString("Windows");
-#elif defined(Q_WS_X11) || defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
+#elif defined(Q_OS_UNIX) // && !defined(Q_OS_DARWIN)
 	return QString("X11");
 #else
 	return QString("unknown");

--- a/src/TWScriptable.cpp
+++ b/src/TWScriptable.cpp
@@ -163,7 +163,7 @@ void TWScriptManager::loadPlugins()
 #if defined(Q_OS_WIN)
 	if (pluginsDir.dirName().toLower() == "debug" || pluginsDir.dirName().toLower() == "release")
 		pluginsDir.cdUp();
-#elif defined(Q_OS_MAC) // "plugins" directory is alongside "MacOS" within the package's Contents dir
+#elif defined(Q_OS_DARWIN) // "plugins" directory is alongside "MacOS" within the package's Contents dir
 	if (pluginsDir.dirName() == "MacOS")
 		pluginsDir.cdUp();
 	if (!pluginsDir.exists("plugins")) { // if not found, try for a dir alongside the .app package

--- a/src/TWUtils.cpp
+++ b/src/TWUtils.cpp
@@ -47,7 +47,7 @@
 
 #pragma mark === TWUtils ===
 
-#if defined(Q_WS_X11) || defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
+#if defined(Q_OS_UNIX) && !defined(Q_OS_DARWIN)
 // compile-time default paths - customize by defining in the .pro file
 #ifndef TW_DICPATH
 #define TW_DICPATH "/usr/share/myspell/dicts"
@@ -91,10 +91,9 @@ const QString TWUtils::getLibraryPath(const QString& subdir, const bool updateOn
 	
 	libRootPath = TWApp::instance()->getPortableLibPath();
 	if (libRootPath.isEmpty()) {
-#if defined(Q_WS_MAC) || defined(Q_OS_MAC)
+#if defined(Q_OS_DARWIN)
 		libRootPath = QDir::homePath() + "/Library/" + TEXWORKS_NAME + "/";
-#endif
-#if defined(Q_WS_X11) || defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
+#elif defined(Q_OS_UNIX) // && !defined(Q_OS_DARWIN)
 		if (subdir == "dictionaries") {
 			libPath = TW_DICPATH;
 			QString dicPath = QString::fromLocal8Bit(getenv("TW_DICPATH"));
@@ -104,8 +103,7 @@ const QString TWUtils::getLibraryPath(const QString& subdir, const bool updateOn
 		}
 		else
 			libRootPath = QDir::homePath() + "/." + TEXWORKS_NAME + "/";
-#endif
-#if defined(Q_WS_WIN) || defined(Q_OS_WIN)
+#else // defined(Q_OS_WIN)
 		libRootPath = QDir::homePath() + "/" + TEXWORKS_NAME + "/";
 #endif
 	}
@@ -275,11 +273,11 @@ void TWUtils::insertHelpMenuItems(QMenu* helpMenu)
 		delete actions[i];
 	}
 
-#if defined(Q_WS_MAC) || defined(Q_OS_MAC)
+#if defined(Q_OS_DARWIN)
 	QDir helpDir(QCoreApplication::applicationDirPath() + "/../texworks-help");
 #else
 	QDir helpDir(QCoreApplication::applicationDirPath() + "/texworks-help");
-#if defined(Q_WS_X11) || defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
+#if defined(Q_OS_UNIX) // && !defined(Q_OS_DARWIN)
 	if (!helpDir.exists())
 		helpDir.cd(TW_HELPPATH);
 #endif
@@ -692,7 +690,7 @@ void TWUtils::zoomToHalfScreen(QWidget *window, bool rhs)
 		// If we still have no valid value for hDiff/wDiff, just guess (on some
 		// platforms)
 		if (hDiff == 0 && wDiff == 0) {
-#if defined(Q_WS_WIN) || defined(Q_OS_WIN)
+#if defined(Q_OS_WIN)
 			// (these values were determined on WinXP with default theme)
 			hDiff = 34;
 			wDiff = 8;
@@ -1192,7 +1190,7 @@ CmdKeyFilter *CmdKeyFilter::filter()
 
 bool CmdKeyFilter::eventFilter(QObject *obj, QEvent *event)
 {
-#if defined(Q_WS_MAC) || defined(Q_OS_MAC)
+#if defined(Q_OS_DARWIN)
 	if (event->type() == QEvent::KeyPress) {
 		QKeyEvent *keyEvent = static_cast<QKeyEvent*>(event);
 		if ((keyEvent->modifiers() & Qt::ControlModifier) != 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@
   Q_IMPORT_PLUGIN (QWindowsIntegrationPlugin);
 #endif
 
-#if defined(Q_WS_WIN) || defined(Q_OS_WIN)
+#if defined(Q_OS_WIN)
 BOOL CALLBACK enumThreadWindowProc(HWND hWnd, LPARAM /*lParam*/)
 {
 	if (IsWindowVisible(hWnd))
@@ -101,7 +101,7 @@ There is NO WARRANTY, to the extent permitted by law.\n\n").arg("2007-2015", "Jo
 		}
 	}
 
-#if defined(Q_WS_WIN) || defined(Q_OS_WIN) // single-instance code for Windows
+#if defined(Q_OS_WIN) // single-instance code for Windows
 #define TW_MUTEX_NAME		"org.tug.texworks-" TEXWORKS_VERSION
 	HANDLE hMutex = CreateMutexA(NULL, FALSE, TW_MUTEX_NAME);
 	if (hMutex == NULL)
@@ -180,7 +180,7 @@ There is NO WARRANTY, to the extent permitted by law.\n\n").arg("2007-2015", "Jo
 		rval = app.exec();
 	}
 
-#if defined(Q_WS_WIN) || defined(Q_OS_WIN)
+#if defined(Q_OS_WIN)
 	CloseHandle(hMutex);
 #endif
 


### PR DESCRIPTION
*Note that the code from this pull request shouldn't be merged just yet, it is only a quick fix and intended as a basis for further discussion.*

The problem is rather simple: With the addition of the `Q_OS_*` macros for Qt5-compatibility, there is now an overlap between `Q_OS_MAC` (defined on OS X) and `Q_OS_UNIX` (also defined on OS X). Since the code blocks guarded by these defines are usually not mutually exclusive, sometimes the code for both OS X and Linux/UNIX runs. This breaks the OS X build as, e.g., `TWUtils::getLibraryPath` now starts to return `~/.TeXworks` instead of `/Library/TeXworks`.

If I'm not mistaken, TeXworks has three major platforms it supports: Windows, OS X and “Other” (Linux, BSD, etc.). I'd suggest to create three macros `TW_OS_WIN`, `TW_OS_MAC`, and `TW_OS_OTHER`, that are mutually exclusive and are defined in a central header (which one would that be?) that is included by *every* other source code file. These macros would then be used everywhere instead of the `Q_WS_*` and `Q_OS_*` macros used right now. Would that be acceptable? If so, I'd be glad to do the work and adapt this pull request.

If the above solution isn't acceptable, maybe it would be best to drop all references to `Q_WS_*` (`Q_OS_*` already exists in all versions of Qt4 I could get a hold of) and make the existing checks a bit more specific. I'd volunteer to do this, if this is the preferred solution.