### PR TITLE
Improvements to CMake documentation generation

### DIFF
--- a/CMake/docs/Rakefile
+++ b/CMake/docs/Rakefile
@@ -4,6 +4,7 @@
 #    http://rtomayko.github.io/rocco/
 #
 require "pathname"
+require "rbconfig" # Detection of host OS for OS-specific code.
 
 # Determine all relevant directories (relative to Rakefile).
 DOC_DIR        = Pathname.new(__FILE__).realpath.dirname
@@ -55,7 +56,13 @@ end
 
 # Generate documentation and then view it.
 task :view => [:docs] do
-  sh "open",
+  # Select OS-specific way of opening a file with the default application.
+  program = case RbConfig::CONFIG["host_os"]
+            when /mswin|mingw|cygwin/ then "start" # Windows
+            when /darwin/ then "open" # OS X
+            else "xdg-open" # Linux, BSD, ...
+            end
+  sh program,
     "#{DOC_DIR + 'html' + 'index.html'}"
 end
 

--- a/CMake/docs/Rakefile
+++ b/CMake/docs/Rakefile
@@ -15,7 +15,7 @@ task :default => [:docs]
 
 # Check if prerequisites are met.
 task :prerequisites do
-  raise "Failed to find 'rocco' binary!" unless File.executable?(rocco_binary)
+  raise "Failed to find 'rocco' script!" unless File.file?(rocco_binary)
   puts "Found 'rocco' in '#{File.dirname(rocco_binary)}'!"
 end
 
@@ -43,7 +43,7 @@ task :docs => [:prerequisites, :clean] do
   cmake_files.each { |f| puts "  * #{f}" }
 
   Dir.chdir ROOT_DIR do
-    sh rocco_binary,
+    ruby rocco_binary,
       "--language=cmake",
       "--output=#{DOC_OUTPUT_DIR}",
       "--template=#{DOC_DIR + 'layout.mustache'}",

--- a/CMake/docs/Rakefile
+++ b/CMake/docs/Rakefile
@@ -8,7 +8,8 @@ require 'rocco/tasks' # Not used, but serves as a good test that Rocco is instal
 
 # Run everything from the project root directory
 DOC_DIR = Pathname.new(__FILE__).realpath.dirname
-ROOT_DIR = DOC_DIR.join '../..'
+DOC_OUTPUT_DIR = DOC_DIR + "html" + "docs"
+ROOT_DIR = DOC_DIR + ".." + ".."
 Dir.chdir ROOT_DIR
 
 # Gather all CMake files
@@ -17,11 +18,28 @@ CMAKE_FILES = Dir['**/CMakeLists.txt'] + Dir['**/*.cmake.in']
 # Remove unwanted items like 'modules/' and 'poppler-data-*/'.
 CMAKE_FILES.reject! { |f| f.start_with?("modules/", "poppler-data-") }
 
-# Generate documentation from comments in CMake files
-task :docs do
+# Remove generated documentation files.
+task :clean do
+  html_files = Dir.chdir(DOC_OUTPUT_DIR) { Dir["**/*.html"] }
+  next if html_files.empty?
+
+  puts "Cleaning '#{DOC_OUTPUT_DIR}' (#{html_files.count} files):"
+  html_files.each do |f|
+    abs_f = DOC_OUTPUT_DIR + f
+    if abs_f.file? then
+      puts "  * #{f}"
+      abs_f.delete
+    else
+      puts "  ! #{f} is not a file"
+    end
+  end
+end
+
+# Generate documentation from comments in CMake files, but clean up first.
+task :docs => [:clean] do
   sh "rocco",
     "--language=cmake",
-    "--output=#{DOC_DIR + 'html' + 'docs'}",
+    "--output=#{DOC_OUTPUT_DIR}",
     "--template=#{DOC_DIR + 'layout.mustache'}",
     *CMAKE_FILES
 end

--- a/CMake/docs/Rakefile
+++ b/CMake/docs/Rakefile
@@ -14,6 +14,9 @@ Dir.chdir ROOT_DIR
 # Gather all CMake files
 CMAKE_FILES = Dir['**/CMakeLists.txt'] + Dir['**/*.cmake.in']
 
+# Remove unwanted items like 'modules/' and 'poppler-data-*/'.
+CMAKE_FILES.reject! { |f| f.start_with?("modules/", "poppler-data-") }
+
 # Generate documentation from comments in CMake files
 task :docs do
   sh "rocco",

--- a/CMake/docs/Rakefile
+++ b/CMake/docs/Rakefile
@@ -1,22 +1,25 @@
-# Simple Rakefile for generating documentation from the CMake buildsystem using
+# Simple Rakefile for generating documentation from the CMake build system using
 # Rocco:
 #
 #    http://rtomayko.github.com/rocco
 #
-require 'pathname'
-require 'rocco/tasks' # Not used, but serves as a good test that Rocco is installed
+require "pathname"
+require "rocco/tasks" # Not used, but implicitly tests that Rocco is installed.
 
-# Run everything from the project root directory
+# Run everything from the project root directory.
 DOC_DIR = Pathname.new(__FILE__).realpath.dirname
 DOC_OUTPUT_DIR = DOC_DIR + "html" + "docs"
 ROOT_DIR = DOC_DIR + ".." + ".."
 Dir.chdir ROOT_DIR
 
-# Gather all CMake files
+# Gather all CMake files.
 CMAKE_FILES = Dir['**/CMakeLists.txt'] + Dir['**/*.cmake.in']
 
 # Remove unwanted items like 'modules/' and 'poppler-data-*/'.
 CMAKE_FILES.reject! { |f| f.start_with?("modules/", "poppler-data-") }
+
+# Make document generation the default task.
+task :default => [:docs]
 
 # Remove generated documentation files.
 task :clean do
@@ -44,10 +47,7 @@ task :docs => [:clean] do
     *CMAKE_FILES
 end
 
-# Make doc generation the default task
-task :default => :docs
-
-# Generate documentation and then view it
+# Generate documentation and then view it.
 task :view => [:docs] do
   sh "open",
     "#{DOC_DIR + 'html' + 'index.html'}"

--- a/CMake/docs/Rakefile
+++ b/CMake/docs/Rakefile
@@ -16,8 +16,8 @@ CMAKE_FILES = Dir['**/CMakeLists.txt'] + Dir['**/*.cmake.in']
 
 # Generate documentation from comments in CMake files
 task :docs do
-  system 'rocco',
-    '--language=cmake',
+  sh "rocco",
+    "--language=cmake",
     "--output=#{DOC_DIR + 'html' + 'docs'}",
     "--template=#{DOC_DIR + 'layout.mustache'}",
     *CMAKE_FILES
@@ -28,5 +28,6 @@ task :default => :docs
 
 # Generate documentation and then view it
 task :view => [:docs] do
-  exec "open #{DOC_DIR + 'html' + 'index.html'}"
+  sh "open",
+    "#{DOC_DIR + 'html' + 'index.html'}"
 end

--- a/CMake/docs/Rakefile
+++ b/CMake/docs/Rakefile
@@ -4,7 +4,6 @@
 #    http://rtomayko.github.com/rocco
 #
 require "pathname"
-require "rocco/tasks" # Not used, but implicitly tests that Rocco is installed.
 
 # Run everything from the project root directory.
 DOC_DIR = Pathname.new(__FILE__).realpath.dirname
@@ -21,8 +20,14 @@ CMAKE_FILES.reject! { |f| f.start_with?("modules/", "poppler-data-") }
 # Make document generation the default task.
 task :default => [:docs]
 
+# Check if prerequisites are met.
+task :prerequisites do
+  raise "Failed to find 'rocco' binary!" unless File.executable?(rocco_binary)
+  puts "Found 'rocco' in '#{File.dirname(rocco_binary)}'!"
+end
+
 # Remove generated documentation files.
-task :clean do
+task :clean => [:prerequisites] do
   html_files = Dir.chdir(DOC_OUTPUT_DIR) { Dir["**/*.html"] }
   next if html_files.empty?
 
@@ -39,8 +44,8 @@ task :clean do
 end
 
 # Generate documentation from comments in CMake files, but clean up first.
-task :docs => [:clean] do
-  sh "rocco",
+task :docs => [:prerequisites, :clean] do
+  sh rocco_binary,
     "--language=cmake",
     "--output=#{DOC_OUTPUT_DIR}",
     "--template=#{DOC_DIR + 'layout.mustache'}",
@@ -51,4 +56,9 @@ end
 task :view => [:docs] do
   sh "open",
     "#{DOC_DIR + 'html' + 'index.html'}"
+end
+
+# Asks 'Gem' for the path to 'rocco' to avoid dependency on proper search path.
+def rocco_binary
+  _binary ||= Gem.bin_path("rocco", "rocco")
 end

--- a/CMake/docs/Rakefile
+++ b/CMake/docs/Rakefile
@@ -5,17 +5,10 @@
 #
 require "pathname"
 
-# Run everything from the project root directory.
-DOC_DIR = Pathname.new(__FILE__).realpath.dirname
+# Determine all relevant directories (relative to Rakefile).
+DOC_DIR        = Pathname.new(__FILE__).realpath.dirname
 DOC_OUTPUT_DIR = DOC_DIR + "html" + "docs"
-ROOT_DIR = DOC_DIR + ".." + ".."
-Dir.chdir ROOT_DIR
-
-# Gather all CMake files.
-CMAKE_FILES = Dir['**/CMakeLists.txt'] + Dir['**/*.cmake.in']
-
-# Remove unwanted items like 'modules/' and 'poppler-data-*/'.
-CMAKE_FILES.reject! { |f| f.start_with?("modules/", "poppler-data-") }
+ROOT_DIR       = DOC_DIR + ".." + ".."
 
 # Make document generation the default task.
 task :default => [:docs]
@@ -45,11 +38,17 @@ end
 
 # Generate documentation from comments in CMake files, but clean up first.
 task :docs => [:prerequisites, :clean] do
-  sh rocco_binary,
-    "--language=cmake",
-    "--output=#{DOC_OUTPUT_DIR}",
-    "--template=#{DOC_DIR + 'layout.mustache'}",
-    *CMAKE_FILES
+  raise "Failed to find source CMake files." if cmake_files.empty?
+  puts "Generating documentation for files:"
+  cmake_files.each { |f| puts "  * #{f}" }
+
+  Dir.chdir ROOT_DIR do
+    sh rocco_binary,
+      "--language=cmake",
+      "--output=#{DOC_OUTPUT_DIR}",
+      "--template=#{DOC_DIR + 'layout.mustache'}",
+      *cmake_files
+  end
 end
 
 # Generate documentation and then view it.
@@ -61,4 +60,15 @@ end
 # Asks 'Gem' for the path to 'rocco' to avoid dependency on proper search path.
 def rocco_binary
   _binary ||= Gem.bin_path("rocco", "rocco")
+end
+
+# Create a (sorted) list of CMake files that should be processed.
+def cmake_files
+  _files ||= Dir.chdir ROOT_DIR do
+    # Gather all CMake files.
+    Dir['**/CMakeLists.txt'] + Dir['**/*.cmake.in']
+  end.reject do |f|
+    # Remove unwanted items like 'modules/' and 'poppler-data-*/'.
+    f.start_with?("modules/", "poppler-data-")
+  end.sort
 end

--- a/CMake/docs/Rakefile
+++ b/CMake/docs/Rakefile
@@ -1,7 +1,7 @@
 # Simple Rakefile for generating documentation from the CMake build system using
 # Rocco:
 #
-#    http://rtomayko.github.com/rocco
+#    http://rtomayko.github.io/rocco/
 #
 require "pathname"
 

--- a/CMake/docs/Rakefile
+++ b/CMake/docs/Rakefile
@@ -49,6 +49,8 @@ task :docs => [:prerequisites, :clean] do
       "--template=#{DOC_DIR + 'layout.mustache'}",
       *cmake_files
   end
+
+  fixup_css_paths
 end
 
 # Generate documentation and then view it.
@@ -71,4 +73,24 @@ def cmake_files
     # Remove unwanted items like 'modules/' and 'poppler-data-*/'.
     f.start_with?("modules/", "poppler-data-")
   end.sort
+end
+
+# Post-processes HTML and replaces absolute CSS URLs with relative ones.
+def fixup_css_paths
+  # URL path of CSS file and full path to CSS file.
+  css_url = "resources/docs.css"
+  css_file = DOC_DIR + "html" + css_url
+
+  # Regular expression that searches for hard-coded CSS URL.
+  css_rex = Regexp.new("\"https?://[^\"]+#{Regexp.escape(css_url)}\"")
+
+  # HTML files to operate on.
+  html_files = Dir.chdir(DOC_OUTPUT_DIR) { Dir["**/*.html"] }
+  html_files.each do |f|
+    abs_f = DOC_OUTPUT_DIR + f
+    css_rel = css_file.relative_path_from(abs_f.dirname)
+    f_data = abs_f.read()
+    f_data.gsub!(css_rex, "\"#{css_rel}\"")
+    IO.write(abs_f, f_data)
+  end
 end

--- a/CMake/docs/Rakefile
+++ b/CMake/docs/Rakefile
@@ -66,10 +66,10 @@ end
 
 # Create a (sorted) list of CMake files that should be processed.
 def cmake_files
-  _files ||= Dir.chdir ROOT_DIR do
+  _files ||= (Dir.chdir ROOT_DIR do
     # Gather all CMake files.
     Dir['**/CMakeLists.txt'] + Dir['**/*.cmake.in']
-  end.reject do |f|
+  end).reject do |f|
     # Remove unwanted items like 'modules/' and 'poppler-data-*/'.
     f.start_with?("modules/", "poppler-data-")
   end.sort

--- a/CMake/docs/html/resources/docs.css
+++ b/CMake/docs/html/resources/docs.css
@@ -161,11 +161,11 @@ table td {
   }
     .navigation.about {
       float: right;
-      margin-right: 260px;
+      margin-right: 10px;
     }
     .navigation.toc {
       float: right;
-      margin-right: 30px;
+      margin-right: 10px;
     }
     .navigation:hover,
     .navigation.active {
@@ -195,9 +195,10 @@ table td {
       position: absolute;
       background: #fff;
       opacity: 0.97;
-      top: 40px; left: 0;
+      top: 40px; right: 0;
       padding: 5px 0;
       margin-left: -1px;
+      margin-right: -1px;
       border: 1px solid #aaa;
       border-top: 0;
       -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 3px;
@@ -208,7 +209,6 @@ table td {
       box-shadow: 0 3px 5px rgba(0,0,0,0.2);
     }
       .navigation .contents p {
-        width: 335px;
         display: block;
         text-transform: none;
         margin: 0px;
@@ -216,12 +216,18 @@ table td {
         border: 1px solid transparent;
         border-left: 0; border-right: 0;
       }
+      .navigation.about .contents p {
+        width: 335px;
+      }
       .navigation.about .contents a {
         display: block;
         text-transform: none;
         padding: 4px 20px;
         border: 1px solid transparent;
         border-left: 0; border-right: 0;
+      }
+      .navigation .contents.menu {
+        width: 450px;
       }
       .navigation .contents.menu a {
         display: block;

--- a/CMake/docs/layout.mustache
+++ b/CMake/docs/layout.mustache
@@ -3,7 +3,8 @@
 <head>
   <meta http-equiv="content-type" content="text/html;charset=utf-8">
   <title>{{ url }}</title>
-  <link rel="stylesheet" href="http://sharpie.github.com/TeXworks/resources/docs.css">
+  <!-- In the future, this needs to be replaced with something that comes from the official TeXworks repository, but we currently have no good alternative to http://sharpie.github.io/TeXworks/resources/docs.css, thus keep it. -->
+  <link rel="stylesheet" type="text/css" href="http://sharpie.github.io/TeXworks/resources/docs.css">
 </head>
 <body>
 <div id='container'>
@@ -20,16 +21,16 @@
       </div>
       <div class="contents">
         <p>This documentation was built using Ryan Tomayko's <strong>Rocco</strong> tool:</p>
-        <a href="http://rtomayko.github.com/rocco">rtomayko.github.com/rocco</a>
+        <a href="http://rtomayko.github.io/rocco/">rtomayko.github.io/rocco/</a>
 
         <p>Which is based on <strong>Docco</strong> by Jeremy Ashkenas:</p>
-        <a href="http://jashkenas.github.com/docco">jashkenas.github.com/docco</a>
+        <a href="http://jashkenas.github.io/docco/">jashkenas.github.io/docco/</a>
 
         <p>The code from this navigation bar was borrowed from the <strong>CoffeeScript</strong> project, also by Jeremy:</p>
-        <a href="http://jashkenas.github.com/coffee-script">jashkenas.github.com/coffee-script</a>
+        <a href="http://coffeescript.org/">coffeescript.org</a>
 
         <p>The templates used to create this page may be found on GitHub:</p>
-        <a href="http://github.com/Sharpie/TeXworks/tree/master/CMake/docs">github.com/Sharpie/TeXworks</a>
+        <a href="https://github.com/TeXworks/texworks/tree/master/CMake/docs">github.com/TeXworks/texworks</a>
 
       </div>
     </div>

--- a/CMake/docs/layout.mustache
+++ b/CMake/docs/layout.mustache
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv="content-type" content="text/html;charset=utf-8">
-  <title>{{ url }}</title>
+  <title>[TeXworks] {{ file }}</title>
   <!-- In the future, this needs to be replaced with something that comes from the official TeXworks repository, but we currently have no good alternative to http://sharpie.github.io/TeXworks/resources/docs.css, thus keep it. -->
   <link rel="stylesheet" type="text/css" href="http://sharpie.github.io/TeXworks/resources/docs.css">
 </head>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 #   │       └── <a href="plugins-src/TWPythonPlugin/CMakeLists.html">CMakeLists.txt</a>
 #   └── CMake
 #       └── packaging
-#           ├── <a href="CMake/packaging/CMakeLists.html">CMakeLists.html</a>
+#           ├── <a href="CMake/packaging/CMakeLists.html">CMakeLists.txt</a>
 #           └── mac
 #               └── <a href="CMake/packaging/mac/MacPackagingTasks.cmake.html">MacPackagingTasks.cmake.in</a>
 # </pre>


### PR DESCRIPTION
The details are all in the commit messages or commits themselves. Note that this only addresses the build system for the CMake documentation, not the documentation inside the CMake files.

Among the improvements:
* Many refinements in the `Rakefile` (new targets, better checks, more features)
* Fixed or updated URLs
* CSS file referenced relative to HTML files to be independent of a fixed hosting location
* Adjusted spacing and alignment of the menus

The commits do not contain a rebuilt documentation. Feel free to do that after the merge in a separate commit, if happy with my changes. For an up-to-date documentation with the changes from this pull request, see <http://uniqmartin.github.io/texworks/> (files in [my `gh-pages` branch](https://github.com/UniqMartin/texworks/tree/gh-pages)).