### PR TITLE
It seems that execute FIND_PACKAGE(PythonInterp) firstly, then run FI…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,9 +320,10 @@ IF ( WITH_PYTHON )
     MARK_AS_ADVANCED(PYTHON_INCLUDE_DIR)
     SET(PYTHONLIBS_FOUND TRUE)
   ELSE ()
-    # **NOTE** For some reason, FindPythonLibs.cmake always seems to default to
-    # `/System/Library/Frameworks/Python.framework/Headers` as the include path
-    # on OS X.
+    # **NOTE**
+    # In order to find the correct version of 'PythonLibs', it seems that we need to run 'FIND_PACKAGE(PythonInterp)' firstly.
+    # In order to find the correct version of 'PythonInterp', we need to set 'PYTHONHOME' environment variable
+    FIND_PACKAGE(PythonInterp)
     FIND_PACKAGE(PythonLibs)
   ENDIF ()
 ENDIF()


### PR DESCRIPTION
…ND_PACKAGE(PythonLibs) will help 'cmake' to find the correct 'PythonLibs'.

without setenv PYTHONHOME
-- Found PythonInterp: /home/sun/INSTALL/python/2.7.13/bin/python (found version "1.4")
-- Found PythonLibs: /home/sun/INSTALL/python/2.7.13/lib/libpython2.7.so (found version "2.7.13")

with setenv PYTHONHOME
-- Found PythonInterp: /home/sun/INSTALL/python/2.7.13/bin/python (found version "2.7.13")
-- Found PythonLibs: /home/sun/INSTALL/python/2.7.13/lib/libpython2.7.so (found version "2.7.13")