### PR TITLE
add "make" to default list of processing tools

### DIFF
--- a/src/TWApp.cpp
+++ b/src/TWApp.cpp
@@ -894,7 +894,11 @@ void TWApp::setDefaultEngineList()
 		<< Engine("ConTeXt (XeTeX)", "texexec" EXE, QStringList("--synctex") << "--xtx" << "$fullname", true)
 		<< Engine("BibTeX", "bibtex" EXE, QStringList("$basename"), false)
 		<< Engine("Biber", "biber" EXE, QStringList("$basename"), false)
-		<< Engine("MakeIndex", "makeindex" EXE, QStringList("$basename"), false);
+		<< Engine("MakeIndex", "makeindex" EXE, QStringList("$basename"), false)
+#if !defined(Q_OS_WIN)
+	        << Engine("Make", "make" EXE, QStringList("SYNCTEX=$synctexoption"), true)
+#endif
+	  ;
 	defaultEngineIndex = 1;
 }
 


### PR DESCRIPTION
Some documents have far more complicated build rules than what the
processing tools listed by default can handle, and so relying on
calling GNU Make to sort it all out is quite common among more
experienced Unix/Linux/macOS users.

(Adding make is the single most common configuration change that I
have to make to new installations of TeXworks.)

I've not added make on Windows, where it is currently rarely installed
(although even that may change in future, e.g. with Microsoft's new
Windows Subsystem for Linux).

This fixes TeXworks/texworks#784