### PR TITLE
fixes #783 unexpected cursor column after backspace followed by up/down

### DIFF
--- a/src/CompletingEdit.cpp
+++ b/src/CompletingEdit.cpp
@@ -557,6 +557,11 @@ void CompletingEdit::handleBackspace(QKeyEvent *e)
 	}
 	else
 		QTextEdit::keyPressEvent(e);
+
+	// Without the following, when pressing Up or Down immediately
+	// after Backspace the cursor ends up in the wrong column.
+	curs.setPosition(curs.position());
+	setTextCursor(curs);
 }
 
 void CompletingEdit::handleOtherKey(QKeyEvent *e)


### PR DESCRIPTION
The added setPosition and setTextCursor calls should
have no effect, but they appear to correct somehow
the incorrect column into which the cursor moves if we
press cursor-up or cursor-down immediately after backspace.