### PR TITLE
change editor font size by Ctrl+Wheel

### DIFF
--- a/src/CompletingEdit.cpp
+++ b/src/CompletingEdit.cpp
@@ -1191,6 +1191,21 @@ void CompletingEdit::resizeEvent(QResizeEvent *e)
 	lineNumberArea->setGeometry(QRect(cr.left(), cr.top(), lineNumberAreaWidth(), cr.height()));
 }
 
+void CompletingEdit::wheelEvent(QWheelEvent *e)
+{
+	if (e->modifiers() & Qt::ControlModifier)
+	{
+		const int fontSizeChange = (e->delta() > 0) ? 1 : -1;
+		QFont ft = font();
+		ft.setPointSize(ft.pointSize() + fontSizeChange);
+		setFont(ft);
+		e->accept();
+		return;
+	}
+
+	QTextEdit::wheelEvent(e);
+}
+
 void CompletingEdit::lineNumberAreaPaintEvent(QPaintEvent *event)
 {
 	Q_ASSERT(lineNumberArea != NULL);

--- a/src/CompletingEdit.cpp
+++ b/src/CompletingEdit.cpp
@@ -49,6 +49,7 @@
 CompletingEdit::CompletingEdit(QWidget *parent)
 	: QTextEdit(parent),
 	  clickCount(0),
+	  wheelDelta(0),
 	  autoIndentMode(-1), prefixLength(0),
 	  smartQuotesMode(-1),
 	  c(NULL), cmpCursor(QTextCursor()),
@@ -1195,10 +1196,17 @@ void CompletingEdit::wheelEvent(QWheelEvent *e)
 {
 	if (e->modifiers() & Qt::ControlModifier)
 	{
-		const int fontSizeChange = (e->delta() > 0) ? 1 : -1;
-		QFont ft = font();
-		ft.setPointSize(ft.pointSize() + fontSizeChange);
-		setFont(ft);
+		wheelDelta += e->delta();  // accumulate wheelDelta for high-resolution mice, which might pass small values.
+		int sign = (wheelDelta < 0) ? -1 : 1;
+        const int stepSize = 120;  // according to Qt docs a standard wheel step corresponds to a delta of 120.
+		int steps = (sign * wheelDelta) / stepSize;  // abs value to guarantee rounding towards 0.
+		if (steps > 0) {
+			QFont ft = font();
+            const int minFontSize = 4;
+			ft.setPointSize(qMax(ft.pointSize() + sign * steps, minFontSize));
+			setFont(ft);
+			wheelDelta = 0;
+		}
 		e->accept();
 		return;
 	}

--- a/src/CompletingEdit.cpp
+++ b/src/CompletingEdit.cpp
@@ -1198,11 +1198,11 @@ void CompletingEdit::wheelEvent(QWheelEvent *e)
 	{
 		wheelDelta += e->delta();  // accumulate wheelDelta for high-resolution mice, which might pass small values.
 		int sign = (wheelDelta < 0) ? -1 : 1;
-        const int stepSize = 120;  // according to Qt docs a standard wheel step corresponds to a delta of 120.
+		const int stepSize = 120;  // according to Qt docs a standard wheel step corresponds to a delta of 120.
 		int steps = (sign * wheelDelta) / stepSize;  // abs value to guarantee rounding towards 0.
 		if (steps > 0) {
 			QFont ft = font();
-            const int minFontSize = 4;
+			const int minFontSize = 4;
 			ft.setPointSize(qMax(ft.pointSize() + sign * steps, minFontSize));
 			setFont(ft);
 			wheelDelta = 0;
@@ -1292,7 +1292,7 @@ void CompletingEdit::setHighlightCurrentLine(bool highlight)
 void CompletingEdit::setAutocompleteEnabled(bool autocomplete)
 {
 	if (autocomplete != autocompleteEnabled) {
-    autocompleteEnabled = autocomplete;
+		autocompleteEnabled = autocomplete;
 	}
 }
 

--- a/src/CompletingEdit.h
+++ b/src/CompletingEdit.h
@@ -154,8 +154,8 @@ private:
 	QBasicTimer clickTimer;
 	QPoint clickPos;
 	int clickCount;
-    
-    int wheelDelta;  // used to accumulate small steps of high-resolution mice
+
+	int wheelDelta;  // used to accumulate small steps of high-resolution mice
 	
 	static void loadIndentModes();
 
@@ -167,7 +167,7 @@ private:
 	int autoIndentMode;
 	int prefixLength;
 
-    static void loadSmartQuotesModes();
+	static void loadSmartQuotesModes();
 	
 	typedef QPair<QString,QString> QuotePair;
 	typedef QHash<QChar,QuotePair> QuoteMapping;

--- a/src/CompletingEdit.h
+++ b/src/CompletingEdit.h
@@ -154,6 +154,8 @@ private:
 	QBasicTimer clickTimer;
 	QPoint clickPos;
 	int clickCount;
+    
+    int wheelDelta;  // used to accumulate small steps of high-resolution mice
 	
 	static void loadIndentModes();
 

--- a/src/CompletingEdit.h
+++ b/src/CompletingEdit.h
@@ -102,6 +102,7 @@ protected:
 	virtual bool canInsertFromMimeData(const QMimeData *source) const;
 	virtual void insertFromMimeData(const QMimeData *source);
 	virtual void resizeEvent(QResizeEvent *event);
+	virtual void wheelEvent(QWheelEvent *event);
 	virtual bool event(QEvent *event);	
 	virtual void scrollContentsBy(int dx, int dy);
 	


### PR DESCRIPTION
Like in most editors the font size should be changable by Ctrl+Wheel.

This implementation does only change the font size of the editor itself. This is different from the behavior of the menu entry `Format -> Font`, which also changes the console output. If maintaining a correlation between the fonts of editor and console is desired, we'll have to add a bit more logic that sends the font change from the editor to a central place and distributes it from there to all affected widgets.