### PR TITLE
Indent/unindent selected text with tab

### DIFF
--- a/src/CompletingEdit.h
+++ b/src/CompletingEdit.h
@@ -72,6 +72,9 @@ public:
 	static void setHighlightCurrentLine(bool highlight);
 	static void setAutocompleteEnabled(bool autocomplete);
 
+	void prefixLines(const QString &prefix);
+	void unPrefixLines(const QString &prefix);
+
 public slots:
 	void setAutoIndentMode(int index);
 	void setSmartQuotesMode(int index);

--- a/src/TeXDocument.cpp
+++ b/src/TeXDocument.cpp
@@ -1826,97 +1826,24 @@ void TeXDocument::doReplaceDialog()
 		doReplace(result);
 }
 
-void TeXDocument::prefixLines(const QString &prefix)
-{
-	QTextCursor cursor = textEdit->textCursor();
-	cursor.beginEditBlock();
-	int selStart = cursor.selectionStart();
-	int selEnd = cursor.selectionEnd();
-	cursor.setPosition(selStart);
-	if (!cursor.atBlockStart()) {
-		cursor.movePosition(QTextCursor::StartOfBlock);
-		selStart = cursor.position();
-	}
-	cursor.setPosition(selEnd);
-	if (!cursor.atBlockStart() || selEnd == selStart) {
-		cursor.movePosition(QTextCursor::NextBlock);
-		selEnd = cursor.position();
-	}
-	if (selEnd == selStart)
-		goto handle_end_of_doc;	// special case - cursor in blank line at end of doc
-	if (!cursor.atBlockStart()) {
-		cursor.movePosition(QTextCursor::StartOfBlock);
-		goto handle_end_of_doc; // special case - unterminated last line
-	}
-	while (cursor.position() > selStart) {
-		cursor.movePosition(QTextCursor::PreviousBlock);
-	handle_end_of_doc:
-		cursor.insertText(prefix);
-		cursor.movePosition(QTextCursor::StartOfBlock);
-		selEnd += prefix.length();
-	}
-	cursor.setPosition(selStart);
-	cursor.setPosition(selEnd, QTextCursor::KeepAnchor);
-	textEdit->setTextCursor(cursor);
-	cursor.endEditBlock();
-}
-
 void TeXDocument::doIndent()
 {
-	prefixLines("\t");
+	textEdit->prefixLines("\t");
 }
 
 void TeXDocument::doComment()
 {
-	prefixLines("%");
-}
-
-void TeXDocument::unPrefixLines(const QString &prefix)
-{
-	QTextCursor cursor = textEdit->textCursor();
-	cursor.beginEditBlock();
-	int selStart = cursor.selectionStart();
-	int selEnd = cursor.selectionEnd();
-	cursor.setPosition(selStart);
-	if (!cursor.atBlockStart()) {
-		cursor.movePosition(QTextCursor::StartOfBlock);
-		selStart = cursor.position();
-	}
-	cursor.setPosition(selEnd);
-	if (!cursor.atBlockStart() || selEnd == selStart) {
-		cursor.movePosition(QTextCursor::NextBlock);
-		selEnd = cursor.position();
-	}
-	if (!cursor.atBlockStart()) {
-		cursor.movePosition(QTextCursor::StartOfBlock);
-		goto handle_end_of_doc; // special case - unterminated last line
-	}
-	while (cursor.position() > selStart) {
-		cursor.movePosition(QTextCursor::PreviousBlock);
-	handle_end_of_doc:
-		cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor);
-		QString		str = cursor.selectedText();
-		if (str == prefix) {
-			cursor.removeSelectedText();
-			selEnd -= prefix.length();
-		}
-		else
-			cursor.movePosition(QTextCursor::PreviousCharacter);
-	}
-	cursor.setPosition(selStart);
-	cursor.setPosition(selEnd, QTextCursor::KeepAnchor);
-	textEdit->setTextCursor(cursor);
-	cursor.endEditBlock();
+	textEdit->prefixLines("%");
 }
 
 void TeXDocument::doUnindent()
 {
-	unPrefixLines("\t");
+	textEdit->unPrefixLines("\t");
 }
 
 void TeXDocument::doUncomment()
 {
-	unPrefixLines("%");
+	textEdit->unPrefixLines("%");
 }
 
 void TeXDocument::toUppercase()

--- a/src/TeXDocument.h
+++ b/src/TeXDocument.h
@@ -236,8 +236,6 @@ private:
 	void saveRecentFileInfo();
 	bool getPreviewFileName(QString &pdfName);
 	bool openPdfIfAvailable(bool show);
-	void prefixLines(const QString &prefix);
-	void unPrefixLines(const QString &prefix);
 	void replaceSelection(const QString& newText);
 	void doHardWrap(int mode, int lineWidth, bool rewrap);
 	void zoomToLeft(QWidget *otherWindow);


### PR DESCRIPTION
This is a proof-of-concept to resolve #299: Selecting some lines and pressing tab / shift-tab will indent / unindent the selection. 

The actual implementation is just a few lines at the end of `CompletingEdit::handleCompletionShortcut`. But I had to move `prefixLines`/`unprefixLines` from `TeXDocument` to `CompletingEdit`, in order to access them there. To keep changes minimal I did not make any other changes to the interface, in particular the `doIndent`, `doComment` etc methods are still in `TeXDocument`.