### PR TITLE
Update syntax highlighting for ConTeXt (see #809)

### DIFF
--- a/res/resfiles/configuration/syntax-patterns.txt
+++ b/res/resfiles/configuration/syntax-patterns.txt
@@ -58,10 +58,10 @@ darkblue N [\=\[\]]
 gray N [\-\+\/\^\_]
 
 # start/stop
-darkgreen	N	\\(?:start|stop)[A-Za-z]+
+darkgreen;B	N	\\(?:start|stop)[A-Za-z]+
 
 # control sequences
-blue		N	\\(?:[A-Za-z@]+|.)
+blue;B		N	\\(?:[A-Za-z@]+|.)
 
 # comments
 red			Y	%.*

--- a/res/resfiles/configuration/syntax-patterns.txt
+++ b/res/resfiles/configuration/syntax-patterns.txt
@@ -45,17 +45,17 @@ darkblue	N	\\usepackage\s*(?:\[[^\]]*\]\s*)?\{[^\}]*\}
 blue		N	\\(?:[A-Za-z@]+|.)
 
 # comments
-red			Y	%.*
+red		Y	%.*
 
 [ConTeXt]
 # special characters
 darkred		N	[\$\#{\}\&]
 
 # 'other' special characters
-darkblue N [\=\[\]]
+darkblue	N	[\=\[\]]
 
 # mathematical operations
-gray N [\-\+\/\^\_]
+gray		N	[\-\+\/\^\_]
 
 # start/stop
 darkgreen;B	N	\\(?:start|stop)[A-Za-z]+
@@ -64,7 +64,7 @@ darkgreen;B	N	\\(?:start|stop)[A-Za-z]+
 blue;B		N	\\(?:[A-Za-z@]+|.)
 
 # comments
-red			Y	%.*
+red		Y	%.*
 
 # other possibilities to be added....
 # [BibTeX]

--- a/res/resfiles/configuration/syntax-patterns.txt
+++ b/res/resfiles/configuration/syntax-patterns.txt
@@ -33,7 +33,7 @@
 
 [LaTeX]
 # special characters
-darkred		N	[\$#\^_\{\}&]
+darkred		N	[\$\#\^\_\{\}\&]
 
 # LaTeX environments
 darkgreen	N	\\(?:begin|end)\s*\{[^\}]*\}
@@ -49,7 +49,7 @@ red			Y	%.*
 
 [ConTeXt]
 # special characters
-darkred		N	[$#^_{}&]
+darkred		N	[\$\#\^\_\{\}\&]
 
 # start/stop
 darkgreen	N	\\(?:start|stop)[A-Za-z]+

--- a/res/resfiles/configuration/syntax-patterns.txt
+++ b/res/resfiles/configuration/syntax-patterns.txt
@@ -49,7 +49,13 @@ red			Y	%.*
 
 [ConTeXt]
 # special characters
-darkred		N	[\$\#\^\_\{\}\&]
+darkred		N	[\$\#{\}\&]
+
+# 'other' special characters
+darkblue N [\=\[\]]
+
+# mathematical operations
+gray N [\-\+\/\^\_]
 
 # start/stop
 darkgreen	N	\\(?:start|stop)[A-Za-z]+

--- a/res/resfiles/configuration/syntax-patterns.txt
+++ b/res/resfiles/configuration/syntax-patterns.txt
@@ -33,7 +33,7 @@
 
 [LaTeX]
 # special characters
-darkred		N	[\$\#\^\_\{\}\&]
+darkred		N	[$#^_{}&]
 
 # LaTeX environments
 darkgreen	N	\\(?:begin|end)\s*\{[^\}]*\}
@@ -49,13 +49,13 @@ red		Y	%.*
 
 [ConTeXt]
 # special characters
-darkred		N	[\$\#{\}\&]
+darkred		N	[$#{}&]
 
 # 'other' special characters
-darkblue	N	[\=\[\]]
+darkblue	N	[=\[\]]
 
 # mathematical operations
-gray		N	[\-\+\/\^\_]
+gray		N	[\-+/^_]
 
 # start/stop
 darkgreen;B	N	\\(?:start|stop)[A-Za-z]+


### PR DESCRIPTION
This keeps the TeXworks 'standard' colours and the idea that `\start...`/`\stop...` are special, but otherwise is closer to ConTeXt's 'own' highlighting than at present.