### PR TITLE
Add highlighting support for LaTeX DTX format

### DIFF
--- a/res/resfiles/configuration/syntax-patterns.txt
+++ b/res/resfiles/configuration/syntax-patterns.txt
@@ -60,6 +60,36 @@ blue		N	\\(?:[A-Za-z@]+|.)
 # comments
 red			Y	%.*
 
+[LaTeX DTX]
+
+# comments
+red		Y	\^\^A.*
+
+# Guards
+darkviolet		N	^%<@@=[^>]*>
+limegreen		N	^%<\*[^>]*>
+crimson		N	^%</[^>]*>
+brown		N	^%<<
+orange		N	^%<[^>]*>
+
+# special characters
+darkred		N	\^\^\^\^\^[0-9a-z]{5}
+darkred		N	\^\^\^\^[0-9a-z]{4}
+darkred		N	\^\^\^[0-9a-z]{3}
+darkred		N	\^\^[0-9a-z]{2}
+darkred		N	[$#^_{}&]
+gray		N	^%%.*
+gray		N	^%
+
+# Macrocode
+green		N	\\(?:begin|end)\{macrocode\}
+
+# LaTeX environments
+darkgreen	N	\\(?:begin|end)\s*\{[^}]*\}
+
+# control sequences
+blue		N	\\(?:[A-Za-z@:_]+|.)
+
 # other possibilities to be added....
 # [BibTeX]
 # [Metapost]


### PR DESCRIPTION
This covers both 'classical' LaTeX2e .dtx files and those for expl3,
hence the presence of "<@@=" and :/_ as 'letters'. One might argue
for separating the two but I suspect at least for a first pass it would
be sensible to do everything in one. (Users can after all modify these
if they wish to have more complex set ups.)

Notice that as .dtx files can contain all sorts of oddities I've
included the extended ^^<char> syntax.

Colours here are inspired by WinEdt's .dtx support coupled with
existing TeXworks conventions.

As with the 'basic' LaTeX scheme it may be worth adding \[\] to the
special chars list (cf. ConTeXt scheme).