### PR TITLE
Add syntax highlighting for Lua code

### DIFF
--- a/res/resfiles/configuration/syntax-patterns.txt
+++ b/res/resfiles/configuration/syntax-patterns.txt
@@ -60,6 +60,22 @@ blue		N	\\(?:[A-Za-z@]+|.)
 # comments
 red			Y	%.*
 
+[Lua]
+
+# Comments (single line only)
+red		Y	--.*
+
+# Strings
+green		N	(?:\"(?:[^\"\\]|\\[\s\S])*(?:\"|$)|\'(?:[^\'\\]|\\[\s\S])*(?:\'|$))
+green		N	\[(=*)\[[\s\S]*(?:\]\1\]|$)
+
+# Keywords
+blue;B		N	
+\b(?:and|break|do|else|elseif|end|false|for|function|if|in|local|nil|not|or|repeat|return|then|true|until|while)\b
+
+# Numbers
+darkblue	N	[+-]?(?:0x[\da-f]+|(?:(?:\.\d+|\d+(?:\.\d*)?)(?:e[+\-]?\d+)?))
+
 # other possibilities to be added....
 # [BibTeX]
 # [Metapost]


### PR DESCRIPTION
As Lua has a short list of 'real' keywords these can be picked out
separately from everything else. Notice that as we are doing line-by-line
highlighting there is no chance of covering Lua's --[[ ... --]] syntax
for comments.

Possibly the string-matching regexes can be made more efficient: may
go with the request for the Qt5 PCRE regex engine to be enabled here.