### PR TITLE
Do not create uninstall shortcut in startmenu

### DIFF
--- a/win32/texworks-setup-script.iss
+++ b/win32/texworks-setup-script.iss
@@ -99,7 +99,6 @@ Name: "{group}\TeXworks"; Filename: "{app}\TeXworks.exe"
 Name: "{group}\{cm:ProgramOnTheWeb,TeXworks}"; Filename: "http://www.tug.org/texworks/"
 Name: "{group}\{cm:ManualNameEn}"; Filename: "{app}\texworks-help\TeXworks-manual\en\TeXworks-manual-en.pdf"
 Name: "{group}\{cm:ManualNameFr}"; Filename: "{app}\texworks-help\TeXworks-manual\fr\TeXworks-manual-fr.pdf"
-Name: "{group}\{cm:UninstallProgram,TeXworks}"; Filename: "{uninstallexe}"
 Name: "{commondesktop}\TeXworks"; Filename: "{app}\TeXworks.exe"; Tasks: desktopicon
 Name: "{commonappdata}\Microsoft\Internet Explorer\Quick Launch\TeXworks"; Filename: "{app}\TeXworks.exe"; Tasks: quicklaunchicon
 


### PR DESCRIPTION
Creating such a start menu entry is a leftover of the ancient Win 3.x time where there was no central control panel for removing programs.

Also see the Windows guidelines, where creating an uninstall shortcut is discouraged: https://msdn.microsoft.com/en-us/library/ms954377.aspx