### PR TITLE
fix link to svg color names

### DIFF
--- a/res/resfiles/configuration/syntax-patterns.txt
+++ b/res/resfiles/configuration/syntax-patterns.txt
@@ -13,7 +13,7 @@
 #
 # The color fields <fgcolor> and <bgcolor> are either:
 # *) a color name from the list defined in the SVG standard;
-#    see http://www.w3.org/TR/SVG/types.html#ColorKeywords
+#    see https://www.w3.org/TR/SVG11/types.html#ColorKeywords
 # *) a hexadecimal color value of the form #rrggbb; note that if this is used at
 #    the beginning of a line, a space " " must be added in front of it so the
 #    line is not interpreted as a comment (e.g., " #aabbcc" instead of "#aabbcc")


### PR DESCRIPTION
This pr fixes the invalid link to svg color names, appearing in comment links of `syntax-patterns.txt`.
https://github.com/TeXworks/texworks/blob/67180ecf44b76d136bccdc6d3e723052ef4d9cb5/res/resfiles/configuration/syntax-patterns.txt#L14-L19

For more info, see https://github.com/TeXworks/manual/pull/7