### PR TITLE
Call function untitled() instead of isUntitled()

### DIFF
--- a/src/TeXDocumentWindow.cpp
+++ b/src/TeXDocumentWindow.cpp
@@ -583,7 +583,7 @@ void TeXDocumentWindow::open()
 	QFileDialog::Options options = QFileDialog::DontResolveSymlinks;
 #if defined(Q_OS_DARWIN)
 		/* use a sheet if we're calling Open from an empty, untitled, untouched window; otherwise use a separate dialog */
-	if (!(isUntitled && textEdit->document()->isEmpty() && !isWindowModified()))
+	if (!(untitled() && textEdit->document()->isEmpty() && !isWindowModified()))
 		options = QFileDialog::DontUseSheet;
 #elif defined(Q_OS_WIN)
 	if(TWApp::GetWindowsVersion() < 0x06000000) options |= QFileDialog::DontUseNativeDialog;


### PR DESCRIPTION
For OS_DARWIN platform, the call is incorrect: `TeXDocumentWindow.cpp:586:8: error: use of undeclared identifier 'isUntitled'`
In TexDocumentWindow.h, the function is called untitled() instead of isUntitled().
I changed it accordingly.

This fixes https://github.com/TeXworks/texworks/issues/885 after installing poppler with
`brew install CMake/packaging/mac/poppler.rb`