### PR TITLE
Remove obsolete options for `brew install poppler`

### DIFF
--- a/BuildingOnMacOSXHomebrew.md
+++ b/BuildingOnMacOSXHomebrew.md
@@ -44,7 +44,7 @@ brew install pkg-config
 brew install cmake
 brew install qt
 brew install hunspell
-brew install poppler --with-qt4 --enable-xpdf-headers
+brew install poppler
 ```
 _Warning: Some of these will take a long time to finish. Especially Qt is quite large (several 100s of MB), so make sure you have a good internet connection and (up to) a couple of hours. The good thing is that each installation should run without requiring any input from you._
 


### PR DESCRIPTION
There are no options “--with-qt” and “--enable-xpdf-headers” anymore.

$ brew info poppler
poppler: stable 0.84.0 (bottled), HEAD
PDF rendering library (based on the xpdf-3.0 code base)
https://poppler.freedesktop.org/
Conflicts with:
pdf2image (because poppler, pdftohtml, pdf2image, and xpdf install conflicting executables)
pdftohtml (because poppler, pdftohtml, pdf2image, and xpdf install conflicting executables)
xpdf (because poppler, pdftohtml, pdf2image, and xpdf install conflicting executables)
/usr/local/Cellar/poppler/0.84.0 (462 files, 24.5MB) *
Poured from bottle on 2020-01-11 at 09:06:38
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/poppler.rb
==> Dependencies
Build: cmake ✔, gobject-introspection ✔, pkg-config ✔
Required: cairo ✔, fontconfig ✔, freetype ✔, gettext ✔, glib ✔, jpeg ✔, libpng ✔, libtiff ✔, little-cms2 ✔, nss ✔, openjpeg ✔, qt ✔
==> Options
--HEAD
Install HEAD version