### PR TITLE
Fix typos in German print dialogue

### DIFF
--- a/src/PDFDocumentWindow.cpp
+++ b/src/PDFDocumentWindow.cpp
@@ -1024,7 +1024,7 @@ void PDFDocumentWindow::print()
 	
 	QString msg = tr("Unfortunately, this version of %1 is unable to print PDF documents due to various technical reasons.\n").arg(QString::fromLatin1(TEXWORKS_NAME));
 	msg += tr("Do you want to open the file in the default viewer for printing instead?");
-	msg += tr(" (Remember to close it again to avoid access problems.)");
+	msg += tr(" (remember to close it again to avoid access problems)");
 	
 	if(QMessageBox::information(this,
 		tr("Print PDF..."), msg,

--- a/src/PDFDocumentWindow.cpp
+++ b/src/PDFDocumentWindow.cpp
@@ -1024,7 +1024,7 @@ void PDFDocumentWindow::print()
 	
 	QString msg = tr("Unfortunately, this version of %1 is unable to print PDF documents due to various technical reasons.\n").arg(QString::fromLatin1(TEXWORKS_NAME));
 	msg += tr("Do you want to open the file in the default viewer for printing instead?");
-	msg += tr(" (remember to close it again to avoid access problems)");
+	msg += tr(" (Remember to close it again to avoid access problems.)");
 	
 	if(QMessageBox::information(this,
 		tr("Print PDF..."), msg,

--- a/trans/TeXworks_de.ts
+++ b/trans/TeXworks_de.ts
@@ -377,7 +377,7 @@ Wollen Sie fortfahren?</translation>
     </message>
     <message>
         <location filename="../src/PDFDocumentWindow.cpp" line="1028"/>
-        <source> (Remember to close it again to avoid access problems.)</source>
+        <source> (remember to close it again to avoid access problems)</source>
         <translation> (Bitte schließen Sie es nach dem Drucken wieder, um Zugriffsprobleme zu vermeiden.)</translation>
     </message>
     <message>

--- a/trans/TeXworks_de.ts
+++ b/trans/TeXworks_de.ts
@@ -362,8 +362,8 @@ Wollen Sie fortfahren?</translation>
     </message>
     <message>
         <location filename="../src/PDFDocumentWindow.cpp" line="1026"/>
-        <source>Unfortunately, this version of %1 is unable to print PDF documents due to various technical reasons.\n</source>
-        <translation>Diese Version von %1 kann aufgrund verschiedener technischer Gründe leider keine PDF Dokumente drucken.\n</translation>
+        <source>Unfortunately, this version of %1 is unable to print PDF documents due to various technical reasons.</source>
+        <translation>Diese Version von %1 kann aufgrund verschiedener technischer Gründe leider keine PDF Dokumente drucken.</translation>
     </message>
     <message>
         <location filename="../src/PDFDocumentWindow.cpp" line="212"/>

--- a/trans/TeXworks_de.ts
+++ b/trans/TeXworks_de.ts
@@ -362,8 +362,7 @@ Wollen Sie fortfahren?</translation>
     </message>
     <message>
         <location filename="../src/PDFDocumentWindow.cpp" line="1026"/>
-        <source>Unfortunately, this version of %1 is unable to print PDF documents due to various technical reasons.
-</source>
+        <source>Unfortunately, this version of %1 is unable to print PDF documents due to various technical reasons.</source>
         <translation>Diese Version von %1 kann aufgrund verschiedener technischer Gründe leider keine PDF Dokumente drucken.</translation>
     </message>
     <message>
@@ -378,8 +377,8 @@ Wollen Sie fortfahren?</translation>
     </message>
     <message>
         <location filename="../src/PDFDocumentWindow.cpp" line="1028"/>
-        <source> (remember to close it again to avoid access problems)</source>
-        <translation> (bitte schließen Sie es nach dem Drucken wieder, um Zugriffsprobleme zu vermeiden)</translation>
+        <source> (Remember to close it again to avoid access problems.)</source>
+        <translation> (Bitte schließen Sie es nach dem Drucken wieder, um Zugriffsprobleme zu vermeiden.)</translation>
     </message>
     <message>
         <location filename="../src/PDFDocumentWindow.ui" line="31"/>

--- a/trans/TeXworks_de.ts
+++ b/trans/TeXworks_de.ts
@@ -362,8 +362,8 @@ Wollen Sie fortfahren?</translation>
     </message>
     <message>
         <location filename="../src/PDFDocumentWindow.cpp" line="1026"/>
-        <source>Unfortunately, this version of %1 is unable to print PDF documents due to various technical reasons.</source>
-        <translation>Diese Version von %1 kann aufgrund verschiedener technischer Gründe leider keine PDF Dokumente drucken.</translation>
+        <source>Unfortunately, this version of %1 is unable to print PDF documents due to various technical reasons.\n</source>
+        <translation>Diese Version von %1 kann aufgrund verschiedener technischer Gründe leider keine PDF Dokumente drucken.\n</translation>
     </message>
     <message>
         <location filename="../src/PDFDocumentWindow.cpp" line="212"/>


### PR DESCRIPTION
Minor fixes in the translation and a grammatical change in the original English text string.

Fixes #895 