### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,9 @@ CMakeLists.txt.user*
 
 # Files created by Inno Setup
 /win32/Output/
+
+# MacOS X files
+.DS_Store
+
+# CMake files
+CMakeUserPresets.json


### PR DESCRIPTION
- `.DS_Store` are automatically created by MacOS X to store OS related informations like display options
- for `CMakeUserPresets.json`, see the cmake [doc](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#introduction)
