### PR TITLE
add dtx tag patterns

### DIFF
--- a/res/resfiles/configuration/tag-patterns.txt
+++ b/res/resfiles/configuration/tag-patterns.txt
@@ -10,11 +10,17 @@
 # as the actual tag text; if there is no group, the entire match will be used.
 
 # Patterns for LaTeX sectioning commands:
-1	^\s*\\part\*?\s*(?:\[[^]]*\]\s*)?\{([^}]*)\}
-2	^\s*\\chapter\*?\s*(?:\[[^]]*\]\s*)?\{([^}]*)\}
-3	^\s*\\section\*?\s*(?:\[[^]]*\]\s*)?\{([^}]*)\}
-4	^\s*\\subsection\*?\s*(?:\[[^]]*\]\s*)?\{([^}]*)\}
-5	^\s*\\subsubsection\*?\s*(?:\[[^]]*\]\s*)?\{([^}]*)\}
+1    ^%?\s*\\part\*?\s*(?:\[[^]]*\]\s*)?\{([^}]*)\}
+2    ^%?\s*\\chapter\*?\s*(?:\[[^]]*\]\s*)?\{([^}]*)\}
+3    ^%?\s*\\section\*?\s*(?:\[[^]]*\]\s*)?\{([^}]*)\}
+4    ^%?\s*\\subsection\*?\s*(?:\[[^]]*\]\s*)?\{([^}]*)\}
+5    ^%?\s*\\subsubsection\*?\s*(?:\[[^]]*\]\s*)?\{([^}]*)\}
+
+# Patterns for dtx files:
+0    ^%\^\^A:\s*(.*?)\s*$
+0    ^%<\*(readme|driver|install)>
+0    ^%?\s*\\begin\*?\{(documentation)\}
+0    ^%?\s*\\begin\*?\{(implementation)\}
 
 # Patterns for ConTeXt sectioning commands (unnumbered):
 # (numbered sections are similar to LaTeX)


### PR DESCRIPTION
in `dtx` files the sectioning commands are prefixed with a `%` character and the comment start with `^^A`.
Only the standard guards `readme`, `install` and `driver` are supported. Other guards may be used dozens of times, which makes the tag tree so big that it becomes unusable.