### PR TITLE
Fix missing application's taskbar icon (fixes #1082)

### DIFF
--- a/res/org.tug.texworks.desktop
+++ b/res/org.tug.texworks.desktop
@@ -48,3 +48,4 @@ Exec=texworks %F
 MimeType=text/x-tex;application/pdf;
 Categories=Office;Qt;
 Keywords=TeX;LaTeX;ConTeXt;XeTeX;PDF;editor;
+StartupWMClass=org.tug.texworks


### PR DESCRIPTION
Solves issue #1082 : missing application's taskbar icon on Ubuntu 24.04.3.

The fix comes from the instructions found in [this](https://itsfoss.com/ubuntu-app-icon-missing/) article.

This is my first time contributing (and hopefully not my last) and I had difficulties compiling and testing the modified version. Thus, it should be checked by someone else to confirm this is not breaking anything else. I would also be happy if someone can explain to me or give me a link that explain how to build and make those tests correctly myself.