### PR TITLE
Add optional language-server support for ConTeXt

### DIFF
--- a/.github/workflows/Dockerfile.legacy
+++ b/.github/workflows/Dockerfile.legacy
@@ -1,6 +1,6 @@
 FROM ubuntu:trusty
 
-# Trusty comes with Qt 5.2.3, poppler 0.24.5
+# The established Trusty proof environment resolves Qt 5.2.1, poppler 0.24.5
 # For CMake (3.5.1) and hunspell (1.3.2), we want to use even older versions
 # (3.1 and 1.2.9, respectively) than are packaged
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+Unreleased
+
+	* Add optional language-server completion and Go to Definition support
+	* Improve modern ConTeXt/LuaMetaTeX support
+
 Release 0.6.11 (TL'26) [February 2026]
 	* Add additional cleanup patterns for LaTeXmk, biblatex, minitoc
 	* List dictionary folders in the "Settings & Resources" dialog

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Getting Started
 
 TeXworks is a free and open-source software project. New users are encouraged to leverage this [guide](https://tug.org/texworks/#How_can_you_help), outlining the fundamental process of creating, formatting, and generating PDF documents from within TeXworks.
 
+For optional language-service configuration and use, see [Using language services](docs/language-services.md).
+
 Contribution
 -------------
 

--- a/docs/development/language-services.md
+++ b/docs/development/language-services.md
@@ -1,0 +1,96 @@
+# Language-service architecture
+
+This document records the current provider-neutral language-service contract.
+It describes the implemented seam; it is not a generic editor-plugin design.
+
+## Ownership and lifecycle
+
+### `LanguageService`
+
+`LanguageService` is the provider-neutral capability and lifecycle interface.
+It owns the contract for starting and stopping a service, document
+synchronization operations, capability reporting, and completion and definition
+requests/results. Provider-specific protocol, process, and UI policy do not
+belong in this interface.
+
+### `LanguageServiceManager`
+
+`LanguageServiceManager` owns active and pending service replacement, lifecycle
+coordination, registered documents, and creation/removal of document bindings.
+It is the authority for associating registered documents with a service.
+
+`TWApp` coordinates persisted configuration: it reads and writes the
+Preferences settings and applies a configured service. It does not own the
+language-service lifecycle or document-binding authority.
+
+### `LanguageServiceDocumentBinding`
+
+Each binding owns one document's service identity and synchronization. This
+includes open/change/close handling, document versions, service and identity
+generations, freshness checks, request tokens, and capability-gated completion
+and definition operations. It also performs UTF-16 position conversion where
+the protocol operation requires positions.
+
+Results must remain fresh for the same service generation, document identity,
+and synchronized version before reaching the UI. This prevents delayed results
+from a changed, renamed, closed, or replaced document from being presented.
+
+## LSP boundary
+
+`LspLanguageService` is the provider/protocol adapter and policy layer for the
+implemented LSP subset. It maps advertised server capabilities and only enables
+operations that TeXworks implements.
+
+`LanguageServerProcess` owns child-process input/output and shutdown handling.
+`JsonRpcTransport` owns generic JSON-RPC framing and request/response
+correlation. Notifications and requests remain distinct. Valid but unsupported
+server-to-client requests receive a provider-neutral JSON-RPC Method-not-found
+rejection; this does not turn server-request features into implemented product
+features.
+
+Protocol, transport, and process authority must not move into `CompletingEdit`,
+`TeXDocumentWindow`, `TeXDocument`, syntax loaders, or other UI/document code.
+
+## UI boundary
+
+`CompletingEdit` and `TeXDocumentWindow` consume capability-gated completion
+and definition results. They do not decide provider protocol or process policy.
+Static completion remains independent of language-service availability.
+
+## Adding another provider
+
+A future provider should implement the `LanguageService` seam and keep its
+protocol and process concerns behind that boundary. Wire configuration through
+the existing application-level coordination as needed, while leaving document
+binding authority with `LanguageServiceManager` and presentation in the UI.
+Do not add provider-specific JSON-RPC or process logic to editor, window, or
+document classes. No plugin architecture is implied by this contract.
+
+## Compatibility contract
+
+The README declares the existing policy floor: CMake 3.1.0, Qt 5.2.3, poppler
+0.24.5, and hunspell 1.2.9. The established clean Trusty proof environment
+resolved Qt 5.2.1 with CMake 3.1.0 and GCC 4.8.4. That older proof is
+compatibility evidence; it does not change the declared Qt 5.2.3 policy floor.
+
+## Optional real-provider validation
+
+These variables are for developers and tests only. Ordinary users configure a
+provider in Preferences and do not use either variable.
+
+- `TEXWORKS_TEST_LANGUAGE_SERVER` enables direct adapter/session validation in
+  `LanguageServiceSessionTest`.
+- `TEXWORKS_LANGUAGE_SERVER` enables production activation/window validation
+  in `LanguageServiceNavigationWindowTest`.
+
+For example:
+
+```sh
+export TEXWORKS_TEST_LANGUAGE_SERVER=/path/to/language-server
+export TEXWORKS_LANGUAGE_SERVER=/path/to/language-server
+```
+
+Setting only one deliberately exercises only its corresponding layer; the
+other optional real-provider test is skipped. Set both, with executable paths
+appropriate for the relevant test, to obtain both kinds of optional
+real-provider evidence.

--- a/docs/language-services.md
+++ b/docs/language-services.md
@@ -1,0 +1,76 @@
+# Using language services
+
+Language services are optional and disabled by default. They add assistance
+from a separately configured external provider without replacing TeXworks'
+normal editor or typesetting workflow. TeXworks does not include a language
+service provider.
+
+TeXworks exposes a provider-neutral language-service feature. Its current
+adapter implements a limited subset of the Language Server Protocol (LSP), so
+it does not promise compatibility with every LSP server. [Digestif](https://github.com/astoff/digestif)
+is a tested example for ConTeXt/LMTX; it is not required to use TeXworks.
+
+## Configure a language service
+
+Open **Preferences**, select **General**, and find **Language Services**.
+
+1. Select **Enable language services**.
+2. Choose the language-server executable with **Browse...** or enter its path.
+3. Enter its arguments with one literal argument on each line. TeXworks does
+   not split a line as a shell would, so quoting or combining several
+   arguments on one line does not create separate arguments.
+4. Click **OK** to save the preferences. The status text reports whether the
+   server is starting, available, stopped, or unavailable.
+
+Each line is passed unchanged as one argument: spaces, quotes, and backslashes
+are literal characters, and a blank line represents an empty argument. No
+shell parsing or expansion is performed.
+
+TeXworks does not find or install a provider automatically. The
+`TEXWORKS_TEST_LANGUAGE_SERVER` and `TEXWORKS_LANGUAGE_SERVER` environment
+variables are for developer tests, not for ordinary configuration.
+
+## ConTeXt documents
+
+Modern ConTeXt files with `.mkiv` and `.mkxl` extensions are identified as
+ConTeXt sources. For a stored `.tex` document, a program modeline takes
+precedence: it is identified as ConTeXt when that modeline names ConTeXt
+(`context`). A different program modeline is not overridden by selecting a
+ConTeXt engine. Only when no program modeline is present can a selected
+ConTeXt engine identify the document as ConTeXt. The default **ConTeXt
+(LuaMetaTeX)** engine remains distinct from **ConTeXt (LuaTeX)**.
+
+Language-service assistance is currently configured for these ConTeXt sources;
+it does not imply support for other TeX dialects.
+
+## Completion
+
+TeXworks' built-in static completion remains available whether or not a
+language service is configured. When the active service advertises completion,
+provider candidates can be added asynchronously to the normal completion
+popup. Keyboard navigation, acceptance, and cancellation use the usual editor
+completion behavior.
+
+## Go to Definition
+
+**Go to Definition** is available when the active service advertises and
+supports definitions for the current synchronized document. A single returned
+usable local-file location is opened and its returned range is selected. If
+the sole returned location cannot be opened or navigated, TeXworks reports
+that the definition location cannot be opened. If no location, or more than
+one location, is returned, TeXworks reports that result instead of choosing
+one.
+
+## If the service is unavailable
+
+With no service configured, an invalid executable, a failed service, or after
+disabling the feature, provider assistance is unavailable. TeXworks keeps
+ordinary editing, typesetting, and static completion independent of the
+service. Correct the Preferences configuration or enable the feature again to
+start a new service.
+
+## Current limits
+
+This feature does not currently provide a diagnostics UI, arbitrary workspace
+semantics, automatic provider discovery, automatic restart, generic
+server-request features, or every LSP capability.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,11 @@ set(TEXWORKS_SRCS BibTeXFile.cpp
                   document/SpellCheckManager.cpp
                   document/TextDocument.cpp
                   document/TeXDocument.cpp
+                  languageservices/LanguageService.cpp
+                  languageservices/LanguageServiceManager.cpp
+                  languageservices/lsp/JsonRpcTransport.cpp
+                  languageservices/lsp/LanguageServerProcess.cpp
+                  languageservices/lsp/LspLanguageService.cpp
                   scripting/ECMAScriptInterface.cpp
                   scripting/ECMAScript.cpp
                   scripting/ScriptAPI.cpp
@@ -94,6 +99,13 @@ set(TEXWORKS_HDRS BibTeXFile.h
                   document/SpellCheckManager.h
                   document/TextDocument.h
                   document/TeXDocument.h
+                  languageservices/LanguageService.h
+                  languageservices/LanguageServiceConfiguration.h
+                  languageservices/LanguageServiceManager.h
+                  languageservices/LanguageServiceTypes.h
+                  languageservices/lsp/JsonRpcTransport.h
+                  languageservices/lsp/LanguageServerProcess.h
+                  languageservices/lsp/LspLanguageService.h
                   scripting/ScriptAPIInterface.h
                   scripting/ScriptLanguageInterface.h
                   scripting/ScriptAPI.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,7 +38,9 @@ set(TEXWORKS_SRCS BibTeXFile.cpp
                   document/TextDocument.cpp
                   document/TeXDocument.cpp
                   languageservices/LanguageService.cpp
+                  languageservices/LanguageServiceDocumentBinding.cpp
                   languageservices/LanguageServiceManager.cpp
+                  languageservices/LanguageServiceNavigation.cpp
                   languageservices/lsp/JsonRpcTransport.cpp
                   languageservices/lsp/LanguageServerProcess.cpp
                   languageservices/lsp/LspLanguageService.cpp
@@ -100,8 +102,10 @@ set(TEXWORKS_HDRS BibTeXFile.h
                   document/TextDocument.h
                   document/TeXDocument.h
                   languageservices/LanguageService.h
+                  languageservices/LanguageServiceDocumentBinding.h
                   languageservices/LanguageServiceConfiguration.h
                   languageservices/LanguageServiceManager.h
+                  languageservices/LanguageServiceNavigation.h
                   languageservices/LanguageServiceTypes.h
                   languageservices/lsp/JsonRpcTransport.h
                   languageservices/lsp/LanguageServerProcess.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,8 @@
 set(TEXWORKS_SRCS BibTeXFile.cpp
                   CitationSelectDialog.cpp
                   CompletingEdit.cpp
+                  DefaultFileFilters.cpp
+                  DefaultEngineList.cpp
                   Engine.cpp
                   FindDialog.cpp
                   HardWrapDialog.cpp
@@ -64,6 +66,8 @@ set(TEXWORKS_HDRS BibTeXFile.h
                   CitationSelectDialog.h
                   CompletingEdit.h
                   DefaultBinaryPaths.h
+                  DefaultFileFilters.h
+                  DefaultEngineList.h
                   DefaultPrefs.h
                   Engine.h
                   FindDialog.h

--- a/src/CompletingEdit.cpp
+++ b/src/CompletingEdit.cpp
@@ -33,19 +33,27 @@
 #include <QAbstractItemView>
 #include <QAbstractTextDocumentLayout>
 #include <QApplication>
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+#include <QDesktopWidget>
+#endif
+#include <QGuiApplication>
 #include <QClipboard>
-#include <QCompleter>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QFrame>
 #include <QKeyEvent>
+#include <QListView>
 #include <QMenu>
 #include <QModelIndex>
 #include <QPainter>
 #include <QScrollBar>
+#include <QScreen>
+#include <QItemSelectionModel>
 #include <QSignalMapper>
 #include <QStandardItem>
 #include <QStandardItemModel>
+#include <QStyle>
 #include <QTextBlock>
 #include <QTextCodec>
 #include <QTextCursor>
@@ -56,11 +64,9 @@ CompletingEdit::CompletingEdit(QWidget *parent /* = nullptr */)
 	: QTextEdit(parent)
 {
 	Tw::Settings settings;
-	if (!sharedCompleter) { // initialize shared (static) members
-		sharedCompleter = new QCompleter(qApp);
-		sharedCompleter->setCompletionMode(QCompleter::InlineCompletion);
-		sharedCompleter->setCaseSensitivity(Qt::CaseInsensitive);
-		loadCompletionFiles(sharedCompleter);
+	if (!sharedCompletionModel) { // initialize shared (static) members
+		sharedCompletionModel = new QStandardItemModel(0, 2, qApp);
+		loadCompletionFiles(sharedCompletionModel);
 
 		currentCompletionFormat = new QTextCharFormat;
 		braceMatchingFormat = new QTextCharFormat;
@@ -88,6 +94,26 @@ CompletingEdit::CompletingEdit(QWidget *parent /* = nullptr */)
 	connect(TWApp::instance(), &TWApp::highlightLineOptionChanged, this, &CompletingEdit::resetExtraSelections);
 
 	setupUi(this);
+	// A non-activating transient keeps the editor as the keyboard owner. Qt::Popup
+	// grabs keys on some Wayland backends, which would defeat that contract.
+	completionPopup = new QFrame(this, Qt::ToolTip);
+	completionPopup->setObjectName(QStringLiteral("completionPopup"));
+	completionPopup->setFocusPolicy(Qt::NoFocus);
+	completionView = new QListView(completionPopup);
+	completionView->setObjectName(QStringLiteral("completionList"));
+	completionView->setAccessibleName(tr("Completions"));
+	completionView->setFocusPolicy(Qt::NoFocus);
+	completionView->setSelectionMode(QAbstractItemView::SingleSelection);
+	completionView->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+	completionListModel = new QStandardItemModel(completionView);
+	completionView->setModel(completionListModel);
+	if (window() != this)
+		window()->installEventFilter(this);
+	connect(completionView, &QListView::clicked, this, [this](const QModelIndex & index) {
+		if (index.isValid())
+			applyCompletion(index.row());
+	});
+	connect(completionView, &QListView::activated, this, [this](const QModelIndex &) { acceptCompletion(); });
 	connect(actionJump_To_PDF, &QAction::triggered, this, [=]() { this->jumpToPdf(); });
 	// As these actions are not used in menus/toolbars, we need to manually add
 	// them to the widget for TWUtils::installCustomShortcuts to work
@@ -215,25 +241,43 @@ void CompletingEdit::updateColors()
 
 CompletingEdit::~CompletingEdit()
 {
-	setCompleter(nullptr);
-}
-
-void CompletingEdit::setCompleter(QCompleter *completer)
-{
-	c = completer;
-	if (!c)
-		return;
-
-	c->setWidget(this);
 }
 
 void CompletingEdit::cursorPositionChangedSlot()
 {
-	setCompleter(nullptr);
-	if (!currentCompletionRange.isNull())
-		currentCompletionRange = QTextCursor();
+	if (applyingCompletion)
+		return;
+	clearCompletionContext();
 	resetExtraSelections();
 	prefixLength = 0;
+}
+
+void CompletingEdit::clearCompletionContext(bool notify)
+{
+	const bool hadContext = completionSession.active;
+	completionSession = CompletionSession();
+	cmpCursor = QTextCursor();
+	currentCompletionRange = QTextCursor();
+	completionListModel->clear();
+	completionPopup->hide();
+	if (notify && hadContext)
+		emit completionContextInvalidated();
+}
+
+void CompletingEdit::cancelCompletion()
+{
+	if (!completionSession.active)
+		return;
+	restoreCompletionPrefix();
+	clearCompletionContext();
+	resetExtraSelections();
+}
+
+void CompletingEdit::setProviderCompletionAvailable(bool available)
+{
+	providerCompletionAvailable = available;
+	if (!available && completionSession.active)
+		emit completionContextInvalidated();
 }
 
 void CompletingEdit::mousePressEvent(QMouseEvent *e)
@@ -563,8 +607,6 @@ void CompletingEdit::timerEvent(QTimerEvent *e)
 
 void CompletingEdit::focusInEvent(QFocusEvent *e)
 {
-	if (c)
-		c->setWidget(this);
 	QTextEdit::focusInEvent(e);
 }
 
@@ -588,9 +630,42 @@ void CompletingEdit::resetExtraSelections()
 
 void CompletingEdit::keyPressEvent(QKeyEvent *e)
 {
+	if (completionSession.active) {
+		const QKeySequence seq(static_cast<int>(e->modifiers()) | e->key());
+		if (seq == actionNext_Completion_Placeholder->shortcut() || seq == actionPrevious_Completion_Placeholder->shortcut()) {
+			acceptCompletion();
+		}
+		else if (e->key() == Qt::Key_Escape) {
+			restoreCompletionPrefix();
+			clearCompletionContext();
+			resetExtraSelections();
+			return;
+		}
+		else if (e->key() == Qt::Key_Return || e->key() == Qt::Key_Enter) {
+			acceptCompletion();
+			return;
+		}
+		else if (e->key() == Qt::Key_Up || e->key() == Qt::Key_Down) {
+			const int next = completionSession.currentIndex + (e->key() == Qt::Key_Up ? -1 : 1);
+			if (next >= 0 && next < completionSession.candidates.size())
+				applyCompletion(next);
+			return;
+		}
+		else if (e->key() == Qt::Key_Backspace && e->modifiers() == Qt::NoModifier) {
+			refilterCompletion(e, true);
+			return;
+		}
+		else if (!e->text().isEmpty() && e->modifiers() == Qt::NoModifier && e->text().at(0).isLetterOrNumber()) {
+			refilterCompletion(e, false);
+			return;
+		}
+		else if (e->key() != Qt::Key_Tab && e->key() != Qt::Key_Backtab) {
+			acceptCompletion();
+		}
+	}
 	if (autocompleteEnabled) {
 		QKeySequence seq(static_cast<int>(e->modifiers()) | e->key());
-		if (seq == actionNext_Completion->shortcut() || seq == actionPrevious_Completion->shortcut() || seq == actionNext_Completion_Placeholder->shortcut() || seq == actionPrevious_Completion_Placeholder->shortcut()) {
+		if (seq == actionNext_Completion->shortcut() || seq == actionPrevious_Completion->shortcut() || e->key() == Qt::Key_Backtab || seq == actionNext_Completion_Placeholder->shortcut() || seq == actionPrevious_Completion_Placeholder->shortcut()) {
 			if (handleCompletionShortcut(e))
 				return;
 		}
@@ -873,8 +948,8 @@ bool CompletingEdit::handleCompletionShortcut(QKeyEvent *e)
 		return true;
 	}
 
-	// if we are at the beginning of the line (i.e., only whitespaces before a
-	// caret cursor), insert a tab (for indentation) instead of doing completion
+	// If we are at the beginning of the line (i.e., only whitespaces before a
+	// caret cursor), insert a tab (for indentation) instead of doing completion.
 	bool atLineStart = false;
 
 	QTextCursor lineStartCursor = textCursor();
@@ -886,89 +961,41 @@ bool CompletingEdit::handleCompletionShortcut(QKeyEvent *e)
 			atLineStart = true;
 	}
 
-	if (!c && !atLineStart) {
-		cmpCursor = textCursor();
-		if (!selectWord(cmpCursor) && textCursor().selectionStart() > 0) {
-			cmpCursor.setPosition(textCursor().selectionStart() - 1);
-			selectWord(cmpCursor);
-		}
-		// check if the word is preceded by open-brace; if so try with that included
-		int start = cmpCursor.selectionStart();
-		int end = cmpCursor.selectionEnd();
-		if (start > 0) { // special cases: possibly look back to include brace or hyphen(s)
-			if (cmpCursor.selectedText() == QLatin1String("-")) {
-				QTextCursor hyphCursor(cmpCursor);
-				int hyphPos = start;
-				while (hyphPos > 0) {
-					hyphCursor.setPosition(hyphPos - 1);
-					hyphCursor.setPosition(hyphPos, QTextCursor::KeepAnchor);
-					if (hyphCursor.selectedText() != QLatin1String("-"))
-						break;
-					--hyphPos;
-				}
-				cmpCursor.setPosition(hyphPos);
-				cmpCursor.setPosition(end, QTextCursor::KeepAnchor);
-			}
-			else if (cmpCursor.selectedText() != QLatin1String("{")) {
-				QTextCursor braceCursor(cmpCursor);
-				braceCursor.setPosition(start - 1);
-				braceCursor.setPosition(start, QTextCursor::KeepAnchor);
-				if (braceCursor.selectedText() == QLatin1String("{")) {
-					cmpCursor.setPosition(start - 1);
-					cmpCursor.setPosition(end, QTextCursor::KeepAnchor);
-				}
-			}
-		}
-
-		while (true) {
-			QString completionPrefix = cmpCursor.selectedText();
-			if (!completionPrefix.isEmpty()) {
-				setCompleter(sharedCompleter);
-				c->setCompletionPrefix(completionPrefix);
-				if (c->completionCount() == 0) {
-					if (cmpCursor.selectionStart() < start) {
-						// we must have included a preceding brace or hyphen; now try without it
-						cmpCursor.setPosition(start);
-						cmpCursor.setPosition(end, QTextCursor::KeepAnchor);
-						continue;
-					}
-					setCompleter(nullptr);
-				}
-				else {
-					if (seq == actionPrevious_Completion->shortcut())
-						c->setCurrentRow(c->completionCount() - 1);
-					showCurrentCompletion();
-					return true;
-				}
-			}
-			break;
-		}
-	}
-
-	if (c && c->completionCount() > 0) {
-		if (seq == actionPrevious_Completion->shortcut()) {
-			if (c->currentRow() == 0) {
-				showCompletion(c->completionPrefix());
-				setCompleter(nullptr);
-			}
-			else {
-				c->setCurrentRow(c->currentRow() - 1);
-				showCurrentCompletion();
-			}
-		}
-		else {
-			if (c->currentRow() == c->completionCount() - 1) {
-				showCompletion(c->completionPrefix());
-				setCompleter(nullptr);
-			}
-			else {
-				c->setCurrentRow(c->currentRow() + 1);
-				showCurrentCompletion();
-			}
-		}
+	if (atLineStart)
+		return false;
+	const bool backwards = seq == actionPrevious_Completion->shortcut() || e->key() == Qt::Key_Backtab;
+	if (!completionSession.active)
+		return beginCompletion(backwards);
+	if (completionSession.candidates.isEmpty())
+		return providerCompletionAvailable;
+	if (!backwards) {
+		acceptCompletion();
 		return true;
 	}
-	return false;
+	const int next = completionSession.currentIndex + (backwards ? -1 : 1);
+	if (next < 0 || next >= completionSession.candidates.size()) {
+		restoreCompletionPrefix();
+		clearCompletionContext();
+		resetExtraSelections();
+	}
+	else {
+		applyCompletion(next);
+	}
+	return true;
+}
+
+void CompletingEdit::refilterCompletion(QKeyEvent * event, bool backspace)
+{
+	// Restore first so the normal QTextEdit operation never edits an expanded
+	// preview. The old request is invalidated before the fresh session begins.
+	restoreCompletionPrefix();
+	clearCompletionContext();
+	if (backspace)
+		handleBackspace(event);
+	else
+		handleOtherKey(event);
+	if (!textCursor().hasSelection())
+		(void)beginCompletion(false);
 }
 
 void CompletingEdit::handleTab(QKeyEvent * e)
@@ -984,69 +1011,261 @@ void CompletingEdit::handleTab(QKeyEvent * e)
 	}
 }
 
-void CompletingEdit::showCompletion(const QString& completion, QString::size_type insOffset)
+bool CompletingEdit::beginCompletion(bool backwards)
 {
-	disconnect(this, &CompletingEdit::cursorPositionChanged, this, &CompletingEdit::cursorPositionChangedSlot);
-
-	if (c->widget() != this)
-		return;
-
-	QTextCursor tc = cmpCursor;
-	if (tc.isNull()) {
-		tc = textCursor();
-		tc.movePosition(QTextCursor::PreviousCharacter, QTextCursor::KeepAnchor, static_cast<pos_type>(c->completionPrefix().length()));
+	cmpCursor = textCursor();
+	if (!selectWord(cmpCursor) && textCursor().selectionStart() > 0) {
+		cmpCursor.setPosition(textCursor().selectionStart() - 1);
+		selectWord(cmpCursor);
+	}
+	int start = cmpCursor.selectionStart();
+	const int end = cmpCursor.selectionEnd();
+	if (start > 0) {
+		if (cmpCursor.selectedText() == QLatin1String("-")) {
+			QTextCursor hyphenCursor(cmpCursor);
+			int hyphenPosition = start;
+			while (hyphenPosition > 0) {
+				hyphenCursor.setPosition(hyphenPosition - 1);
+				hyphenCursor.setPosition(hyphenPosition, QTextCursor::KeepAnchor);
+				if (hyphenCursor.selectedText() != QLatin1String("-"))
+					break;
+				--hyphenPosition;
+			}
+			cmpCursor.setPosition(hyphenPosition);
+			cmpCursor.setPosition(end, QTextCursor::KeepAnchor);
+		}
+		else if (cmpCursor.selectedText() != QLatin1String("{")) {
+			QTextCursor braceCursor(cmpCursor);
+			braceCursor.setPosition(start - 1);
+			braceCursor.setPosition(start, QTextCursor::KeepAnchor);
+			if (braceCursor.selectedText() == QLatin1String("{")) {
+				cmpCursor.setPosition(start - 1);
+				cmpCursor.setPosition(end, QTextCursor::KeepAnchor);
+			}
+		}
 	}
 
-	tc.insertText(completion);
-	cmpCursor = tc;
-	cmpCursor.movePosition(QTextCursor::PreviousCharacter, QTextCursor::KeepAnchor, static_cast<pos_type>(completion.length()));
+	const auto appendStatic = [this](int prefixStart, int prefixEnd) {
+		const QString prefix = cmpCursor.selectedText();
+		for (int row = 0; row < sharedCompletionModel->rowCount(); ++row) {
+			const QString label = sharedCompletionModel->item(row, 0)->text();
+			if (!label.startsWith(prefix, Qt::CaseInsensitive))
+				continue;
+			CompletionCandidate candidate;
+			candidate.insertText = sharedCompletionModel->item(row, 1)->text();
+			candidate.insertionOffset = candidate.insertText.indexOf(QLatin1String("#INS#"));
+			if (candidate.insertionOffset != -1)
+				candidate.insertText.remove(QLatin1String("#INS#"));
+			candidate.replacedText = prefix;
+			candidate.replacementStart = prefixStart;
+			candidate.replacementEnd = prefixEnd;
+			candidate.id = static_cast<quint64>(row) + 1;
+			candidate.sourceRow = row;
+			candidate.label = label;
+			completionSession.candidates.append(candidate);
+		}
+	};
 
-	if (insOffset != -1)
-		tc.movePosition(QTextCursor::PreviousCharacter, QTextCursor::MoveAnchor, static_cast<pos_type>(completion.length() - insOffset));
-	setTextCursor(tc);
+	completionSession.candidates.clear();
+	appendStatic(cmpCursor.selectionStart(), cmpCursor.selectionEnd());
+	if (completionSession.candidates.isEmpty() && cmpCursor.selectionStart() < start) {
+		cmpCursor.setPosition(start);
+		cmpCursor.setPosition(end, QTextCursor::KeepAnchor);
+		appendStatic(start, end);
+	}
+	if (cmpCursor.selectedText().isEmpty())
+		return false;
 
-	currentCompletionRange = cmpCursor;
-	resetExtraSelections();
-
-	connect(this, &CompletingEdit::cursorPositionChanged, this, &CompletingEdit::cursorPositionChangedSlot);
+	completionSession.active = true;
+	completionSession.baseText = text();
+	completionSession.position.line = textCursor().blockNumber();
+	completionSession.position.character = textCursor().positionInBlock();
+	completionSession.currentIndex = -1;
+	if (providerCompletionAvailable)
+		emit completionRequested(completionSession.position);
+	if (!completionSession.candidates.isEmpty()) {
+		applyCompletion(backwards ? static_cast<int>(completionSession.candidates.size()) - 1 : 0);
+		return true;
+	}
+	if (providerCompletionAvailable)
+		return true;
+	clearCompletionContext(false);
+	return false;
 }
 
-void CompletingEdit::showCurrentCompletion()
+void CompletingEdit::restoreCompletionPrefix()
 {
-	if (c->widget() != this)
+	if (completionSession.currentIndex < 0 || currentCompletionRange.isNull())
 		return;
+	emit completionEditStarted();
+	applyingCompletion = true;
+	QTextCursor cursor = currentCompletionRange;
+	cursor.insertText(completionSession.candidates.at(completionSession.currentIndex).replacedText);
+	cursor.clearSelection();
+	cursor.setPosition(absolutePosition(completionSession.position));
+	setTextCursor(cursor);
+	applyingCompletion = false;
+	emit completionEditFinished();
+}
 
-	QStandardItemModel *model = qobject_cast<QStandardItemModel*>(c->model());
-	QList<QStandardItem*> items = model->findItems(c->currentCompletion());
+void CompletingEdit::acceptCompletion()
+{
+	if (!completionSession.active)
+		return;
+	clearCompletionContext();
+	resetExtraSelections();
+}
 
-	if (items.count() > 1) {
-		if (c->currentCompletion() == prevCompletion) {
-			if (c->currentIndex().row() > prevRow)
-				++itemIndex;
-			else
-				--itemIndex;
-			if (itemIndex < 0)
-				itemIndex = items.count() - 1;
-			else if (itemIndex > items.count() - 1)
-				itemIndex = 0;
+void CompletingEdit::updateCompletionPopup()
+{
+	if (!completionSession.active || completionSession.currentIndex < 0)
+		return;
+	completionListModel->clear();
+	for (const CompletionCandidate & candidate : completionSession.candidates) {
+		auto * item = new QStandardItem(candidate.label.isEmpty() ? candidate.insertText : candidate.label);
+		item->setData(QVariant::fromValue<qulonglong>(candidate.id), Qt::UserRole);
+		completionListModel->appendRow(item);
+	}
+	completionView->setFont(font());
+	const QModelIndex selected = completionListModel->index(completionSession.currentIndex, 0);
+	completionView->setCurrentIndex(selected);
+	completionView->selectionModel()->select(selected, QItemSelectionModel::ClearAndSelect);
+	positionCompletionPopup();
+	completionPopup->show();
+}
+
+void CompletingEdit::positionCompletionPopup()
+{
+	if (completionListModel->rowCount() == 0)
+		return;
+	const int rows = qMin(8, completionListModel->rowCount());
+	const QFontMetrics metrics(font());
+	const int rowHeight = qMax(metrics.height(), completionView->sizeHintForRow(0));
+	QRect cursor = cursorRect();
+	QPoint point = viewport()->mapToGlobal(cursor.bottomLeft());
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+	const QRect available = QApplication::desktop()->availableGeometry(point);
+#else
+	QScreen * targetScreen = screen() ? screen() : QGuiApplication::primaryScreen();
+	const QRect available = targetScreen->availableGeometry();
+#endif
+	const int width = qMin(qMax(completionView->sizeHintForColumn(0) +
+	                            completionView->frameWidth() * 2 +
+	                            completionView->style()->pixelMetric(QStyle::PM_ScrollBarExtent), 160),
+	                       available.width());
+	const int height = qMin(rowHeight * rows + 4, available.height());
+	completionView->setGeometry(0, 0, width, height);
+	completionPopup->resize(completionView->size());
+	if (point.y() + completionPopup->height() > available.bottom())
+		point.setY(viewport()->mapToGlobal(cursor.topLeft()).y() - completionPopup->height());
+	point.setX(qBound(available.left(), point.x(), available.right() - completionPopup->width() + 1));
+	point.setY(qBound(available.top(), point.y(), available.bottom() - completionPopup->height() + 1));
+	completionPopup->move(point);
+}
+
+void CompletingEdit::applyCompletion(int index)
+{
+	if (index < 0 || index >= completionSession.candidates.size())
+		return;
+	emit completionEditStarted();
+	applyingCompletion = true;
+	QTextCursor cursor(document());
+	cursor.beginEditBlock();
+	if (completionSession.currentIndex >= 0 && !currentCompletionRange.isNull()) {
+		QTextCursor restore = currentCompletionRange;
+		restore.insertText(completionSession.candidates.at(completionSession.currentIndex).replacedText);
+	}
+	const CompletionCandidate & candidate = completionSession.candidates.at(index);
+	cursor.setPosition(candidate.replacementStart);
+	cursor.setPosition(candidate.replacementEnd, QTextCursor::KeepAnchor);
+	cursor.insertText(candidate.insertText);
+	cursor.endEditBlock();
+	currentCompletionRange = QTextCursor(document());
+	currentCompletionRange.setPosition(candidate.replacementStart);
+	currentCompletionRange.setPosition(candidate.replacementStart + static_cast<int>(candidate.insertText.size()), QTextCursor::KeepAnchor);
+	QTextCursor displayCursor = currentCompletionRange;
+	displayCursor.clearSelection();
+	if (candidate.insertionOffset != -1)
+		displayCursor.setPosition(candidate.replacementStart + static_cast<int>(candidate.insertionOffset));
+	setTextCursor(displayCursor);
+	cmpCursor = currentCompletionRange;
+	completionSession.currentIndex = index;
+	applyingCompletion = false;
+	emit completionEditFinished();
+	resetExtraSelections();
+	updateCompletionPopup();
+}
+
+int CompletingEdit::absolutePosition(const Tw::LanguageServices::LanguagePosition & position) const
+{
+	if (position.line < 0 || position.character < 0)
+		return -1;
+	int line = 0;
+	int lineStart = 0;
+	while (line < position.line) {
+		const int newline = static_cast<int>(completionSession.baseText.indexOf(QLatin1Char('\n'), lineStart));
+		if (newline < 0)
+			return -1;
+		lineStart = newline + 1;
+		++line;
+	}
+	const int newline = static_cast<int>(completionSession.baseText.indexOf(QLatin1Char('\n'), lineStart));
+	const int lineEnd = newline < 0 ? static_cast<int>(completionSession.baseText.size()) : newline;
+	return position.character <= lineEnd - lineStart ? lineStart + position.character : -1;
+}
+
+void CompletingEdit::mergeProviderCompletions(const QList<Tw::LanguageServices::CompletionItem> & items)
+{
+	if (!completionSession.active)
+		return;
+	for (const Tw::LanguageServices::CompletionItem & item : items) {
+		int replacementStart = cmpCursor.selectionStart();
+		int replacementEnd = cmpCursor.selectionEnd();
+		if (item.hasReplacementRange) {
+			if (item.replacementRange.start.line != item.replacementRange.end.line
+			    || item.replacementRange.end.line != completionSession.position.line
+			    || item.replacementRange.end.character != completionSession.position.character)
+				continue;
+			replacementStart = absolutePosition(item.replacementRange.start);
+			replacementEnd = absolutePosition(item.replacementRange.end);
+			if (replacementStart < 0 || replacementEnd < replacementStart)
+				continue;
 		}
-		else
-			itemIndex = 0;
-		prevRow = c->currentIndex().row();
-		prevCompletion = c->currentCompletion();
+		else {
+			replacementStart = completionSession.candidates.isEmpty() ? cmpCursor.selectionStart()
+			                                                    : completionSession.candidates.first().replacementStart;
+			replacementEnd = completionSession.candidates.isEmpty() ? cmpCursor.selectionEnd()
+			                                                  : completionSession.candidates.first().replacementEnd;
+		}
+		bool duplicate = false;
+		for (const CompletionCandidate & existing : completionSession.candidates) {
+			if (existing.insertText == item.insertText
+			    && existing.replacementStart == replacementStart
+			    && existing.replacementEnd == replacementEnd) {
+				duplicate = true;
+				break;
+			}
+		}
+		if (duplicate)
+			continue;
+		CompletionCandidate candidate;
+		candidate.id = (quint64(1) << 32) | completionSession.nextProviderId++;
+		candidate.source = CompletionCandidate::Provider;
+		candidate.label = item.label;
+		candidate.insertText = item.insertText;
+		candidate.replacementStart = replacementStart;
+		candidate.replacementEnd = replacementEnd;
+		candidate.replacedText = completionSession.baseText.mid(replacementStart, replacementEnd - replacementStart);
+		completionSession.candidates.append(candidate);
 	}
-	else {
-		prevCompletion = QString();
-		itemIndex = 0;
+	if (completionSession.currentIndex < 0 && completionSession.candidates.isEmpty()) {
+		clearCompletionContext(false);
+		resetExtraSelections();
 	}
-
-	QString completion = model->item(items[itemIndex]->row(), 1)->text();
-
-	auto insOffset = completion.indexOf(QLatin1String("#INS#"));
-	if (insOffset != -1)
-		completion.replace(QLatin1String("#INS#"), QLatin1String(""));
-
-	showCompletion(completion, insOffset);
+	else if (completionSession.currentIndex < 0)
+		applyCompletion(0);
+	else
+		updateCompletionPopup();
 }
 
 void CompletingEdit::loadCompletionsFromFile(QStandardItemModel *model, const QString& filename)
@@ -1081,16 +1300,13 @@ void CompletingEdit::loadCompletionsFromFile(QStandardItemModel *model, const QS
 	}
 }
 
-void CompletingEdit::loadCompletionFiles(QCompleter *theCompleter)
+void CompletingEdit::loadCompletionFiles(QStandardItemModel *model)
 {
-	QStandardItemModel *model = new QStandardItemModel(0, 2, theCompleter); // columns are abbrev, expansion
-
 	QDir completionDir(Tw::Utils::ResourcesLibrary::getLibraryPath(QStringLiteral("completion")));
 	foreach (QFileInfo fileInfo, completionDir.entryInfoList(QDir::Files | QDir::Readable, QDir::Name)) {
 		loadCompletionsFromFile(model, fileInfo.canonicalFilePath());
 	}
 
-	theCompleter->setModel(model);
 }
 
 void CompletingEdit::jumpToPdf(QTextCursor pos)
@@ -1340,6 +1556,8 @@ void CompletingEdit::resizeEvent(QResizeEvent *e)
 
 	QRect cr = contentsRect();
 	lineNumberArea->setGeometry(QRect(cr.left(), cr.top(), lineNumberArea->sizeHint().width(), cr.height()));
+	if (completionSession.active && completionPopup->isVisible())
+		positionCompletionPopup();
 }
 
 void CompletingEdit::wheelEvent(QWheelEvent *e)
@@ -1407,7 +1625,7 @@ bool CompletingEdit::event(QEvent *e)
 	if (e->type() == QEvent::ShortcutOverride) {
 		auto ke = reinterpret_cast<QKeyEvent*>(e);
 		QKeySequence seq(static_cast<int>(ke->modifiers()) | ke->key());
-		if (seq == actionNext_Completion->shortcut() ||
+		if (seq == actionNext_Completion->shortcut() || ke->key() == Qt::Key_Backtab ||
 			seq == actionPrevious_Completion->shortcut() ||
 			seq == actionNext_Completion_Placeholder->shortcut() ||
 			seq == actionPrevious_Completion_Placeholder->shortcut())
@@ -1423,12 +1641,21 @@ bool CompletingEdit::event(QEvent *e)
 	return QTextEdit::event(e);
 }
 
+bool CompletingEdit::eventFilter(QObject *watched, QEvent *event)
+{
+	if (watched == window() && event->type() == QEvent::WindowDeactivate)
+		cancelCompletion();
+	return QTextEdit::eventFilter(watched, event);
+}
+
 void CompletingEdit::scrollContentsBy(int dx, int dy)
 {
 	if (dy != 0) {
 		emit updateRequest(viewport()->rect(), dy);
 	}
 	QTextEdit::scrollContentsBy(dx, dy);
+	if (completionSession.active && completionPopup->isVisible())
+		positionCompletionPopup();
 }
 
 Tw::Document::SpellChecker CompletingEdit::getSpellChecker() const
@@ -1494,7 +1721,7 @@ QTextCharFormat	*CompletingEdit::currentLineFormat = nullptr;
 bool CompletingEdit::highlightCurrentLine = true;
 bool CompletingEdit::autocompleteEnabled = true;
 
-QCompleter	*CompletingEdit::sharedCompleter = nullptr;
+QStandardItemModel *CompletingEdit::sharedCompletionModel = nullptr;
 
 QList<CompletingEdit::IndentMode> *CompletingEdit::indentModes = nullptr;
 QList<CompletingEdit::QuotesMode> *CompletingEdit::quotesModes = nullptr;

--- a/src/CompletingEdit.h
+++ b/src/CompletingEdit.h
@@ -24,6 +24,7 @@
 
 #include "ui/LineNumberWidget.h"
 #include "ui_CompletingEdit.h"
+#include "languageservices/LanguageServiceTypes.h"
 
 #include <QDrag>
 #include <QHash>
@@ -32,9 +33,10 @@
 #include <QTextEdit>
 #include <QTimer>
 
-class QCompleter;
 class QStandardItemModel;
 class QTextCodec;
+class QFrame;
+class QListView;
 
 namespace Tw {
 namespace Document {
@@ -81,6 +83,8 @@ public:
 
 	static void setHighlightCurrentLine(bool highlight);
 	static void setAutocompleteEnabled(bool autocomplete);
+	void setProviderCompletionAvailable(bool available);
+	void mergeProviderCompletions(const QList<Tw::LanguageServices::CompletionItem> & items);
 
 	void prefixLines(const QString &prefix);
 	void unPrefixLines(const QString &prefix);
@@ -100,6 +104,10 @@ signals:
 	void syncClick(int line, int col);
 	void rehighlight();
 	void updateRequest(const QRect& rect, int dy);
+	void completionRequested(const Tw::LanguageServices::LanguagePosition & position);
+	void completionContextInvalidated();
+	void completionEditStarted();
+	void completionEditFinished();
 
 protected:
 	void keyPressEvent(QKeyEvent *e) override;
@@ -117,6 +125,7 @@ protected:
 	void resizeEvent(QResizeEvent *event) override;
 	void wheelEvent(QWheelEvent *event) override;
 	bool event(QEvent *event) override;
+	bool eventFilter(QObject *watched, QEvent *event) override;
 	void scrollContentsBy(int dx, int dy) override;
 
 	Tw::Document::SpellChecker getSpellChecker() const;
@@ -134,13 +143,19 @@ private slots:
 private:
 	void updateColors();
 
-	void setCompleter(QCompleter *c);
-
-	void showCompletion(const QString& completion, QString::size_type insOffset = -1);
-	void showCurrentCompletion();
+	void clearCompletionContext(bool notify = true);
+	void cancelCompletion();
+	void applyCompletion(int index);
+	void restoreCompletionPrefix();
+	void acceptCompletion();
+	bool beginCompletion(bool backwards);
+	int absolutePosition(const Tw::LanguageServices::LanguagePosition & position) const;
+	void updateCompletionPopup();
+	void positionCompletionPopup();
+	void refilterCompletion(QKeyEvent * event, bool backspace);
 
 	void loadCompletionsFromFile(QStandardItemModel *model, const QString& filename);
-	void loadCompletionFiles(QCompleter *theCompleter);
+	void loadCompletionFiles(QStandardItemModel *model);
 
 	bool handleCompletionShortcut(QKeyEvent *e);
 	void handleReturn(QKeyEvent *e);
@@ -196,16 +211,39 @@ private:
 
 	int smartQuotesMode{-1};
 
-	QCompleter * c{nullptr};
 	QTextCursor cmpCursor;
-
-	QString prevCompletion; // used with multiple entries for the same key (e.g., "--")
-	QList<void*>::size_type itemIndex{0};
-	int prevRow{-1};
+	struct CompletionCandidate {
+		enum Source { Static, Provider };
+		quint64 id{0};
+		int sourceRow{-1};
+		Source source{Static};
+		QString label;
+		QString insertText;
+		QString replacedText;
+		int replacementStart{0};
+		int replacementEnd{0};
+		QString::size_type insertionOffset{-1};
+	};
+	// Presentation-local state only. Provider request freshness remains in the
+	// document binding; this stores the immutable base and rows it has accepted.
+	struct CompletionSession {
+		QList<CompletionCandidate> candidates;
+		QString baseText;
+		Tw::LanguageServices::LanguagePosition position;
+		quint64 nextProviderId{1};
+		int currentIndex{-1};
+		bool active{false};
+	};
+	CompletionSession completionSession;
+	bool providerCompletionAvailable{false};
+	bool applyingCompletion{false};
 
 	QTextCursor currentWord;
 
 	QTextCursor	currentCompletionRange;
+	QFrame *completionPopup{nullptr};
+	QListView *completionView{nullptr};
+	QStandardItemModel *completionListModel{nullptr};
 
 	Tw::UI::LineNumberWidget * lineNumberArea;
 
@@ -213,7 +251,7 @@ private:
 	static QTextCharFormat	*braceMatchingFormat;
 	static QTextCharFormat	*currentLineFormat;
 
-	static QCompleter	*sharedCompleter;
+	static QStandardItemModel *sharedCompletionModel;
 
 	static bool highlightCurrentLine;
 	static bool autocompleteEnabled;

--- a/src/DefaultEngineList.cpp
+++ b/src/DefaultEngineList.cpp
@@ -1,0 +1,54 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  Jonathan Kew, Stefan Löffler, Charlie Sharpsteen
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+	For links to further information, or to contact the authors,
+	see <https://tug.org/texworks/>.
+*/
+
+#include "DefaultEngineList.h"
+
+#if defined(Q_OS_WIN)
+#define ENGINE_EXE ".exe"
+#else
+#define ENGINE_EXE
+#endif
+
+namespace Tw {
+namespace DefaultEngineList {
+
+QList<Definition> definitions()
+{
+	//	<< Engine("LaTeXmk", "latexmk" EXE, QStringList("-e") <<
+	//			  "$pdflatex=q/pdflatex -synctex=1 %O %S/" << "-pdf" << "$fullname", true)
+	return QList<Definition>()
+	    << Definition{QString::fromLatin1("pdfTeX"), QString::fromLatin1("pdftex" ENGINE_EXE), QStringList(QString::fromLatin1("$synctexoption")) << QString::fromLatin1("$fullname"), true, QString{}}
+	    << Definition{QString::fromLatin1("pdfLaTeX"), QString::fromLatin1("pdflatex" ENGINE_EXE), QStringList(QString::fromLatin1("$synctexoption")) << QString::fromLatin1("$fullname"), true, QString{}}
+	    << Definition{QString::fromLatin1("LuaTeX"), QString::fromLatin1("luatex" ENGINE_EXE), QStringList(QString::fromLatin1("$synctexoption")) << QString::fromLatin1("$fullname"), true, QString{}}
+	    << Definition{QString::fromLatin1("LuaLaTeX"), QString::fromLatin1("lualatex" ENGINE_EXE), QStringList(QString::fromLatin1("$synctexoption")) << QString::fromLatin1("$fullname"), true, QString{}}
+	    << Definition{QString::fromLatin1("XeTeX"), QString::fromLatin1("xetex" ENGINE_EXE), QStringList(QString::fromLatin1("$synctexoption")) << QString::fromLatin1("$fullname"), true, QString{}}
+	    << Definition{QString::fromLatin1("XeLaTeX"), QString::fromLatin1("xelatex" ENGINE_EXE), QStringList(QString::fromLatin1("$synctexoption")) << QString::fromLatin1("$fullname"), true, QString{}}
+	    << Definition{QString::fromLatin1("ConTeXt (LuaMetaTeX)"), QString::fromLatin1("context" ENGINE_EXE), QStringList(QString::fromLatin1("--synctex=repeat")) << QString::fromLatin1("$fullname"), true, QString::fromLatin1("context")}
+	    << Definition{QString::fromLatin1("ConTeXt (LuaTeX)"), QString::fromLatin1("context" ENGINE_EXE), QStringList(QString::fromLatin1("--synctex=repeat")) << QString::fromLatin1("--luatex") << QString::fromLatin1("$fullname"), true, QString::fromLatin1("context")}
+	    << Definition{QString::fromLatin1("ConTeXt (pdfTeX)"), QString::fromLatin1("texexec" ENGINE_EXE), QStringList(QString::fromLatin1("--synctex")) << QString::fromLatin1("$fullname"), true, QString::fromLatin1("context")}
+	    << Definition{QString::fromLatin1("ConTeXt (XeTeX)"), QString::fromLatin1("texexec" ENGINE_EXE), QStringList(QString::fromLatin1("--synctex")) << QString::fromLatin1("--xtx") << QString::fromLatin1("$fullname"), true, QString::fromLatin1("context")}
+	    << Definition{QString::fromLatin1("BibTeX"), QString::fromLatin1("bibtex" ENGINE_EXE), QStringList(QString::fromLatin1("$basename")), false, QString{}}
+	    << Definition{QString::fromLatin1("Biber"), QString::fromLatin1("biber" ENGINE_EXE), QStringList(QString::fromLatin1("$basename")), false, QString{}}
+	    << Definition{QString::fromLatin1("MakeIndex"), QString::fromLatin1("makeindex" ENGINE_EXE), QStringList(QString::fromLatin1("$basename")), false, QString{}};
+}
+
+} // namespace DefaultEngineList
+} // namespace Tw

--- a/src/DefaultEngineList.h
+++ b/src/DefaultEngineList.h
@@ -1,0 +1,46 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  Jonathan Kew, Stefan Löffler, Charlie Sharpsteen
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+	For links to further information, or to contact the authors,
+	see <https://tug.org/texworks/>.
+*/
+
+#ifndef DEFAULTENGINELIST_H
+#define DEFAULTENGINELIST_H
+
+#include <QList>
+#include <QString>
+#include <QStringList>
+
+namespace Tw {
+namespace DefaultEngineList {
+
+struct Definition
+{
+	QString name;
+	QString program;
+	QStringList arguments;
+	bool showPdf;
+	QString sourceLanguage;
+};
+
+QList<Definition> definitions();
+
+} // namespace DefaultEngineList
+} // namespace Tw
+
+#endif // DEFAULTENGINELIST_H

--- a/src/DefaultFileFilters.cpp
+++ b/src/DefaultFileFilters.cpp
@@ -1,0 +1,89 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  Jonathan Kew, Stefan Löffler, Charlie Sharpsteen
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+	For links to further information, or to contact the authors,
+	see <https://tug.org/texworks/>.
+*/
+
+#include "DefaultFileFilters.h"
+
+#include <QFileInfo>
+#include <QObject>
+
+namespace Tw {
+namespace DefaultFileFilters {
+
+QStringList texDocumentNameFilters()
+{
+	return QStringList()
+	    << QStringLiteral("*.tex")
+	    << QStringLiteral("*.mkiv")
+	    << QStringLiteral("*.mkxl");
+}
+
+QStringList filters()
+{
+	QStringList defaultFilters;
+	QString texDocumentFilter{QObject::tr("TeX documents (*.tex)")};
+	texDocumentFilter.replace(QStringLiteral("*.tex"), texDocumentNameFilters().join(QLatin1Char(' ')));
+	defaultFilters << texDocumentFilter;
+	defaultFilters << QObject::tr("LaTeX documents (*.ltx)");
+	defaultFilters << QObject::tr("Log files (*.log *.blg)");
+	defaultFilters << QObject::tr("BibTeX databases (*.bib)");
+	defaultFilters << QObject::tr("Style files (*.sty)");
+	defaultFilters << QObject::tr("Class files (*.cls)");
+	defaultFilters << QObject::tr("Documented macros (*.dtx)");
+	defaultFilters << QObject::tr("Auxiliary files (*.aux *.toc *.lot *.lof *.nav *.out *.snm *.ind *.idx *.bbl *.brf)");
+	defaultFilters << QObject::tr("Text files (*.txt)");
+	defaultFilters << QObject::tr("PDF documents (*.pdf)");
+#ifdef Q_OS_WIN
+	// It seems (contrary to documentation) that on Windows, this has to be
+	// *.* to allow saving files with non-standard extensions (though *.* still
+	// does not allow to save without any extension at all, see below)
+	const QString allFilesFilter = QStringLiteral("*.*");
+//	const QString allFilesFilter = QStringLiteral("*");
+#else
+	// On other systems, *.* might require a . in the filename, which would
+	// preclude filenames without extension. In line with the documentation, *
+	// should be used in those cases
+	const QString allFilesFilter = QStringLiteral("*");
+#endif
+	defaultFilters << QObject::tr("All files") + QStringLiteral(" (%1)").arg(allFilesFilter);
+	return defaultFilters;
+}
+
+QString chooseForFile(const QString & filename, const QStringList & filters)
+{
+	QString extension = QFileInfo(filename).completeSuffix();
+
+	if (extension.isEmpty())
+		return filters.last();
+
+	foreach (QString filter, filters) {
+		// return filter if it corresponds to the given extension
+		// note that the extension must be the first one in the list to match;
+		// otherwise, the file dialog would replace the actual extension by the
+		// first one in the list, thereby altering it without cause
+		if (filter.contains(QString::fromLatin1("(*.%1").arg(extension)))
+			return filter;
+	}
+	// if no filter matched, return the last one (which should be "All files")
+	return filters.last();
+}
+
+} // namespace DefaultFileFilters
+} // namespace Tw

--- a/src/DefaultFileFilters.h
+++ b/src/DefaultFileFilters.h
@@ -1,0 +1,37 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  Jonathan Kew, Stefan Löffler, Charlie Sharpsteen
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+	For links to further information, or to contact the authors,
+	see <https://tug.org/texworks/>.
+*/
+
+#ifndef DEFAULTFILEFILTERS_H
+#define DEFAULTFILEFILTERS_H
+
+#include <QStringList>
+
+namespace Tw {
+namespace DefaultFileFilters {
+
+QStringList texDocumentNameFilters();
+QStringList filters();
+QString chooseForFile(const QString & filename, const QStringList & filters);
+
+} // namespace DefaultFileFilters
+} // namespace Tw
+
+#endif // DEFAULTFILEFILTERS_H

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -24,13 +24,15 @@
 
 #include <QDir>
 
-Engine::Engine(const QString& name, const QString& program, const QStringList & arguments, bool showPdf)
-	: _name(name), _program(program), _arguments(arguments), _showPdf(showPdf)
+Engine::Engine(const QString& name, const QString& program, const QStringList & arguments, bool showPdf,
+	           const QString & sourceLanguage)
+	: _name(name), _program(program), _arguments(arguments), _showPdf(showPdf), _sourceLanguage(sourceLanguage)
 {
 }
 
 Engine::Engine(const Engine& orig)
-	: _name(orig._name), _program(orig._program), _arguments(orig._arguments), _showPdf(orig._showPdf)
+	: _name(orig._name), _program(orig._program), _arguments(orig._arguments), _showPdf(orig._showPdf),
+	  _sourceLanguage(orig._sourceLanguage)
 {
 }
 
@@ -40,6 +42,7 @@ Engine& Engine::operator=(const Engine& rhs)
 	_program = rhs._program;
 	_arguments = rhs._arguments;
 	_showPdf = rhs._showPdf;
+	_sourceLanguage = rhs._sourceLanguage;
 	return *this;
 }
 
@@ -63,6 +66,11 @@ bool Engine::showPdf() const
 	return _showPdf;
 }
 
+const QString Engine::sourceLanguage() const
+{
+	return _sourceLanguage;
+}
+
 void Engine::setName(const QString& name)
 {
 	_name = name;
@@ -81,6 +89,11 @@ void Engine::setArguments(const QStringList& arguments)
 void Engine::setShowPdf(bool showPdf)
 {
 	_showPdf = showPdf;
+}
+
+void Engine::setSourceLanguage(const QString & sourceLanguage)
+{
+	_sourceLanguage = sourceLanguage;
 }
 
 bool Engine::isAvailable() const

--- a/src/Engine.h
+++ b/src/Engine.h
@@ -29,7 +29,8 @@ class Engine
 {
 public:
 	Engine() = default;
-	Engine(const QString& name, const QString& program, const QStringList & arguments, bool showPdf);
+	Engine(const QString& name, const QString& program, const QStringList & arguments, bool showPdf,
+	       const QString & sourceLanguage = QString{});
 	Engine(const Engine& orig);
 	Engine& operator=(const Engine& rhs);
 
@@ -37,11 +38,13 @@ public:
 	const QString program() const;
 	const QStringList arguments() const;
 	bool showPdf() const;
+	const QString sourceLanguage() const;
 
 	void setName(const QString& name);
 	void setProgram(const QString& program);
 	void setArguments(const QStringList& arguments);
 	void setShowPdf(bool showPdf);
+	void setSourceLanguage(const QString & sourceLanguage);
 
 	bool isAvailable() const;
 	QProcess * run(const QFileInfo & input, QObject * parent = nullptr);
@@ -55,6 +58,7 @@ private:
 	QString _program;
 	QStringList _arguments;
 	bool _showPdf{false};
+	QString _sourceLanguage;
 };
 
 

--- a/src/PrefsDialog.cpp
+++ b/src/PrefsDialog.cpp
@@ -65,10 +65,31 @@ void PrefsDialog::init()
 	connect(toolAdd, &QToolButton::clicked, this, &PrefsDialog::addTool);
 	connect(toolRemove, &QToolButton::clicked, this, &PrefsDialog::removeTool);
 	connect(toolEdit, &QToolButton::clicked, this, [=]() { this->editTool(); });
+	connect(languageServicesEnabled, &QCheckBox::toggled,
+	        this, &PrefsDialog::updateLanguageServiceControls);
+	connect(browseLanguageServer, &QPushButton::clicked,
+	        this, &PrefsDialog::browseForLanguageServer);
 
 	connect(tabWidget, &QTabWidget::currentChanged, this, &PrefsDialog::changedTabPanel);
 
 	pathsChanged = toolsChanged = false;
+}
+
+void PrefsDialog::updateLanguageServiceControls(bool enabled)
+{
+	languageServerExecutableLabel->setEnabled(enabled);
+	languageServerExecutable->setEnabled(enabled);
+	browseLanguageServer->setEnabled(enabled);
+	languageServerArgumentsLabel->setEnabled(enabled);
+	languageServerArguments->setEnabled(enabled);
+}
+
+void PrefsDialog::browseForLanguageServer()
+{
+	const QString program = QFileDialog::getOpenFileName(this, tr("Select language server executable"),
+	                                                     languageServerExecutable->text());
+	if (!program.isEmpty())
+		languageServerExecutable->setText(QDir::toNativeSeparators(program));
 }
 
 void PrefsDialog::changedTabPanel(int index)
@@ -308,6 +329,9 @@ void PrefsDialog::restoreDefaults()
 			}
 			localePopup->setCurrentIndex(kDefault_Locale);
 			openPDFwithTeX->setChecked(kDefault_OpenPDFwithTeX);
+			languageServicesEnabled->setChecked(false);
+			languageServerExecutable->clear();
+			languageServerArguments->clear();
 			break;
 
 		case 1:
@@ -494,6 +518,22 @@ QDialog::DialogCode PrefsDialog::doPrefsDialog(QWidget *parent)
 
 	Tw::Settings settings;
 	// initialize controls based on the current settings
+	const Tw::LanguageServiceSettings languageServiceSettings = settings.languageServiceSettings();
+	dlg.languageServicesEnabled->setChecked(languageServiceSettings.enabled);
+	dlg.languageServerExecutable->setText(languageServiceSettings.executable);
+	dlg.languageServerArguments->setPlainText(languageServiceSettings.arguments.join(QChar::fromLatin1('\n')));
+	dlg.updateLanguageServiceControls(languageServiceSettings.enabled);
+	dlg.languageServiceStatus->setText(TWApp::instance()->languageServiceStatusText());
+	connect(&TWApp::instance()->languageServiceManager(),
+	        &Tw::LanguageServices::LanguageServiceManager::stateChanged, &dlg,
+	        [&dlg](Tw::LanguageServices::LanguageService::State) {
+		        dlg.languageServiceStatus->setText(TWApp::instance()->languageServiceStatusText());
+	        });
+	connect(&TWApp::instance()->languageServiceManager(),
+	        &Tw::LanguageServices::LanguageServiceManager::failed, &dlg,
+	        [&dlg](const QString &) {
+		        dlg.languageServiceStatus->setText(TWApp::instance()->languageServiceStatusText());
+	        });
 
 	// General
 	int oldIconSize = settings.value(QString::fromLatin1("toolBarIconSize"), kDefault_ToolBarIcons).toInt();
@@ -726,6 +766,19 @@ QDialog::DialogCode PrefsDialog::doPrefsDialog(QWidget *parent)
 		settings.setValue(QString::fromLatin1("launchOption"), launchOption);
 
 		settings.setValue(QString::fromLatin1("openPDFwithTeX"), dlg.openPDFwithTeX->isChecked());
+
+		Tw::LanguageServiceSettings newLanguageServiceSettings;
+		newLanguageServiceSettings.enabled = dlg.languageServicesEnabled->isChecked();
+		newLanguageServiceSettings.executable = dlg.languageServerExecutable->text();
+		const QString argumentsText = dlg.languageServerArguments->toPlainText();
+		if (!argumentsText.isEmpty()) {
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+			newLanguageServiceSettings.arguments = argumentsText.split(QChar::fromLatin1('\n'), QString::KeepEmptyParts);
+#else
+			newLanguageServiceSettings.arguments = argumentsText.split(QChar::fromLatin1('\n'), Qt::KeepEmptyParts);
+#endif
+		}
+		TWApp::instance()->setLanguageServiceSettings(newLanguageServiceSettings);
 
 		if (dlg.localePopup->currentIndex() != oldLocaleIndex) {
 			switch (dlg.localePopup->currentIndex()) {

--- a/src/PrefsDialog.h
+++ b/src/PrefsDialog.h
@@ -57,6 +57,8 @@ private slots:
 	void addTool();
 	void removeTool();
 	void editTool(QListWidgetItem* item = nullptr);
+	void browseForLanguageServer();
+	void updateLanguageServiceControls(bool enabled);
 
 private:
 	void init();

--- a/src/PrefsDialog.ui
+++ b/src/PrefsDialog.ui
@@ -158,7 +158,70 @@
          </property>
         </spacer>
        </item>
-       <item row="3" column="0">
+       <item row="3" column="0" colspan="2">
+        <widget class="QGroupBox" name="languageServicesGroup">
+         <property name="title">
+          <string>Language Services</string>
+         </property>
+         <layout class="QGridLayout">
+          <item row="0" column="0" colspan="3">
+           <widget class="QCheckBox" name="languageServicesEnabled">
+            <property name="text">
+             <string>Enable language services</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="languageServerExecutableLabel">
+            <property name="text">
+             <string>Language server:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="languageServerExecutable"/>
+          </item>
+          <item row="1" column="2">
+           <widget class="QPushButton" name="browseLanguageServer">
+            <property name="text">
+             <string>Browse...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="languageServerArgumentsLabel">
+            <property name="text">
+             <string>Arguments:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1" colspan="2">
+           <widget class="QPlainTextEdit" name="languageServerArguments">
+            <property name="toolTip">
+             <string>Enter one literal argument per line.</string>
+            </property>
+            <property name="maximumHeight">
+             <number>70</number>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="3">
+           <widget class="QLabel" name="languageServiceStatus">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="4" column="0">
         <spacer>
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -47,6 +47,22 @@ QString Settings::fileName() const
 	return m_s.fileName();
 }
 
+LanguageServiceSettings Settings::languageServiceSettings() const
+{
+	LanguageServiceSettings settings;
+	settings.enabled = m_s.value(QStringLiteral("LanguageServices/enabled"), false).toBool();
+	settings.executable = m_s.value(QStringLiteral("LanguageServices/executable")).toString();
+	settings.arguments = m_s.value(QStringLiteral("LanguageServices/arguments")).toStringList();
+	return settings;
+}
+
+void Settings::setLanguageServiceSettings(const LanguageServiceSettings & settings)
+{
+	m_s.setValue(QStringLiteral("LanguageServices/enabled"), settings.enabled);
+	m_s.setValue(QStringLiteral("LanguageServices/executable"), settings.executable);
+	m_s.setValue(QStringLiteral("LanguageServices/arguments"), settings.arguments);
+}
+
 void Settings::setPortableIniPath(const QString &iniPath)
 {
 	QSettings::setDefaultFormat(QSettings::IniFormat);

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -22,8 +22,24 @@
 #define SETTINGS_H
 
 #include <QSettings>
+#include <QStringList>
 
 namespace Tw {
+
+struct LanguageServiceSettings
+{
+	bool enabled{false};
+	QString executable;
+	QStringList arguments;
+
+	bool operator==(const LanguageServiceSettings & other) const
+	{
+		return enabled == other.enabled
+		       && executable == other.executable
+		       && arguments == other.arguments;
+	}
+	bool operator!=(const LanguageServiceSettings & other) const { return !(*this == other); }
+};
 
 class Settings
 {
@@ -43,6 +59,8 @@ public:
 	QVariant value(KeyType key, const QVariant & defaultValue = QVariant()) const;
 
 	QString fileName() const;
+	LanguageServiceSettings languageServiceSettings() const;
+	void setLanguageServiceSettings(const LanguageServiceSettings & settings);
 
 	static void setPortableIniPath(const QString & iniPath);
 #if defined(Q_OS_WIN)

--- a/src/TWApp.cpp
+++ b/src/TWApp.cpp
@@ -137,6 +137,7 @@ TWApp::TWApp(int &argc, char **argv)
 
 TWApp::~TWApp()
 {
+	m_languageServiceManager.stop();
 	if (scriptManager) {
 		scriptManager->saveDisabledList();
 		delete scriptManager;

--- a/src/TWApp.cpp
+++ b/src/TWApp.cpp
@@ -22,6 +22,7 @@
 #include "TWApp.h"
 
 #include "DefaultBinaryPaths.h"
+#include "DefaultEngineList.h"
 #include "DefaultPrefs.h"
 #include "PDFDocumentWindow.h"
 #include "PrefsDialog.h"
@@ -1099,22 +1100,10 @@ void TWApp::setDefaultEngineList()
 		engineList = std::unique_ptr< QList<Engine> >(new QList<Engine>);
 	else
 		engineList->clear();
-	*engineList
-//		<< Engine("LaTeXmk", "latexmk" EXE, QStringList("-e") <<
-//				  "$pdflatex=q/pdflatex -synctex=1 %O %S/" << "-pdf" << "$fullname", true)
-	    << Engine(QString::fromLatin1("pdfTeX"), QString::fromLatin1("pdftex" EXE), QStringList(QString::fromLatin1("$synctexoption")) << QString::fromLatin1("$fullname"), true)
-	    << Engine(QString::fromLatin1("pdfLaTeX"), QString::fromLatin1("pdflatex" EXE), QStringList(QString::fromLatin1("$synctexoption")) << QString::fromLatin1("$fullname"), true)
-	    << Engine(QString::fromLatin1("LuaTeX"), QString::fromLatin1("luatex" EXE), QStringList(QString::fromLatin1("$synctexoption")) << QString::fromLatin1("$fullname"), true)
-	    << Engine(QString::fromLatin1("LuaLaTeX"), QString::fromLatin1("lualatex" EXE), QStringList(QString::fromLatin1("$synctexoption")) << QString::fromLatin1("$fullname"), true)
-	    << Engine(QString::fromLatin1("XeTeX"), QString::fromLatin1("xetex" EXE), QStringList(QString::fromLatin1("$synctexoption")) << QString::fromLatin1("$fullname"), true)
-	    << Engine(QString::fromLatin1("XeLaTeX"), QString::fromLatin1("xelatex" EXE), QStringList(QString::fromLatin1("$synctexoption")) << QString::fromLatin1("$fullname"), true)
-	    << Engine(QString::fromLatin1("ConTeXt (LuaMetaTeX)"), QString::fromLatin1("context" EXE), QStringList(QString::fromLatin1("--synctex=repeat")) << QString::fromLatin1("$fullname"), true)
-	    << Engine(QString::fromLatin1("ConTeXt (LuaTeX)"), QString::fromLatin1("context" EXE), QStringList(QString::fromLatin1("--synctex=repeat")) << QString::fromLatin1("--luatex") << QString::fromLatin1("$fullname"), true)
-	    << Engine(QString::fromLatin1("ConTeXt (pdfTeX)"), QString::fromLatin1("texexec" EXE), QStringList(QString::fromLatin1("--synctex")) << QString::fromLatin1("$fullname"), true)
-	    << Engine(QString::fromLatin1("ConTeXt (XeTeX)"), QString::fromLatin1("texexec" EXE), QStringList(QString::fromLatin1("--synctex")) << QString::fromLatin1("--xtx") << QString::fromLatin1("$fullname"), true)
-	    << Engine(QString::fromLatin1("BibTeX"), QString::fromLatin1("bibtex" EXE), QStringList(QString::fromLatin1("$basename")), false)
-	    << Engine(QString::fromLatin1("Biber"), QString::fromLatin1("biber" EXE), QStringList(QString::fromLatin1("$basename")), false)
-	    << Engine(QString::fromLatin1("MakeIndex"), QString::fromLatin1("makeindex" EXE), QStringList(QString::fromLatin1("$basename")), false);
+	for (const Tw::DefaultEngineList::Definition & definition : Tw::DefaultEngineList::definitions()) {
+		engineList->append(Engine(definition.name, definition.program, definition.arguments,
+		                          definition.showPdf, definition.sourceLanguage));
+	}
 	defaultEngineIndex = 1;
 }
 
@@ -1135,6 +1124,18 @@ const QList<Engine> TWApp::getEngineList()
 				eng.setProgram(toolsSettings.value(QString::fromLatin1("program")).toString());
 				eng.setArguments(toolsSettings.value(QString::fromLatin1("arguments")).toStringList());
 				eng.setShowPdf(toolsSettings.value(QString::fromLatin1("showPdf")).toBool());
+				eng.setSourceLanguage(toolsSettings.value(QString::fromLatin1("language")).toString());
+				if (!toolsSettings.contains(QString::fromLatin1("language"))) {
+					for (const Tw::DefaultEngineList::Definition & definition : Tw::DefaultEngineList::definitions()) {
+						if (eng.name() == definition.name && eng.program() == definition.program
+						    && eng.arguments() == definition.arguments && eng.showPdf() == definition.showPdf) {
+							eng.setSourceLanguage(definition.sourceLanguage);
+							if (!definition.sourceLanguage.isEmpty())
+								toolsSettings.setValue(QString::fromLatin1("language"), definition.sourceLanguage);
+							break;
+						}
+					}
+				}
 				engineList->append(eng);
 				toolsSettings.endGroup();
 			}
@@ -1161,6 +1162,8 @@ void TWApp::saveEngineList()
 		toolsSettings.setValue(QString::fromLatin1("program"), e.program());
 		toolsSettings.setValue(QString::fromLatin1("arguments"), e.arguments());
 		toolsSettings.setValue(QString::fromLatin1("showPdf"), e.showPdf());
+		if (!e.sourceLanguage().isEmpty())
+			toolsSettings.setValue(QString::fromLatin1("language"), e.sourceLanguage());
 		toolsSettings.endGroup();
 	}
 }
@@ -1586,4 +1589,3 @@ void TWApp::reloadSpellchecker()
 		it.key()->setSpellcheckLanguage(it.value());
 	}
 }
-

--- a/src/TWApp.cpp
+++ b/src/TWApp.cpp
@@ -32,6 +32,8 @@
 #include "TeXDocumentWindow.h"
 #include "TemplateDialog.h"
 #include "document/SpellCheckManager.h"
+#include "languageservices/LanguageServiceConfiguration.h"
+#include "languageservices/lsp/LspLanguageService.h"
 #include "scripting/ScriptAPI.h"
 #include "utils/CommandlineParser.h"
 #include "utils/IniConfig.h"
@@ -52,6 +54,7 @@
 #include <QMenu>
 #include <QMenuBar>
 #include <QMessageBox>
+#include <QStatusBar>
 #include <QString>
 #include <QStringList>
 #include <QTextCodec>
@@ -167,7 +170,19 @@ void TWApp::init()
 	theAppInstance = this;
 
 	Tw::Settings settings;
-
+	connect(&m_languageServiceManager, &Tw::LanguageServices::LanguageServiceManager::failed,
+	        this, [this](const QString & reason) {
+		        m_languageServiceNotice = tr("Language server unavailable: %1").arg(reason);
+		        m_languageServiceNoticeShown = false;
+		        showPendingLanguageServiceNotice();
+	        });
+	connect(&m_languageServiceManager, &Tw::LanguageServices::LanguageServiceManager::stateChanged,
+	        this, [this](Tw::LanguageServices::LanguageService::State state) {
+		        if (state == Tw::LanguageServices::LanguageService::Ready) {
+			        m_languageServiceNotice.clear();
+			        m_languageServiceNoticeShown = false;
+		        }
+	        });
 	QString locale = settings.value(QString::fromLatin1("locale"), QLocale::system().name()).toString();
 	applyTranslation(locale);
 
@@ -183,6 +198,7 @@ void TWApp::init()
 	TWUtils::readConfig();
 
 	scriptManager = new TWScriptManager;
+	applyLanguageServiceSettings(settings.languageServiceSettings());
 
 	connect(this, &QGuiApplication::focusObjectChanged, this, [=](QObject * focusObj) {
 		QWidget * widget = qobject_cast<QWidget*>(focusObj);
@@ -1249,6 +1265,85 @@ void TWApp::setDefaultCodec(QTextCodec *codec)
 void TWApp::activatedWindow(QWidget* theWindow)
 {
 	emit hideFloatersExcept(theWindow);
+	showPendingLanguageServiceNotice(theWindow);
+}
+
+Tw::LanguageServiceSettings TWApp::languageServiceSettings() const
+{
+	return Tw::Settings{}.languageServiceSettings();
+}
+
+void TWApp::setLanguageServiceSettings(const Tw::LanguageServiceSettings & settings)
+{
+	Tw::Settings persistentSettings;
+	const Tw::LanguageServiceSettings previous = persistentSettings.languageServiceSettings();
+	persistentSettings.setLanguageServiceSettings(settings);
+	if (settings != previous)
+		applyLanguageServiceSettings(settings);
+}
+
+void TWApp::applyLanguageServiceSettings(const Tw::LanguageServiceSettings & settings)
+{
+	if (!settings.enabled) {
+		m_languageServiceNotice.clear();
+		m_languageServiceNoticeShown = false;
+		m_languageServiceManager.replaceService(nullptr);
+		return;
+	}
+	if (settings.executable.trimmed().isEmpty()) {
+		m_languageServiceNotice = tr("Language services are enabled, but no language server is configured.");
+		m_languageServiceNoticeShown = false;
+		m_languageServiceManager.replaceService(nullptr);
+		showPendingLanguageServiceNotice();
+		return;
+	}
+
+	m_languageServiceNotice.clear();
+	m_languageServiceNoticeShown = false;
+	Tw::LanguageServices::LanguageServiceConfiguration configuration;
+	configuration.executable = settings.executable;
+	configuration.arguments = settings.arguments;
+	auto * service = new Tw::LanguageServices::Lsp::LspLanguageService(configuration);
+	m_languageServiceManager.replaceService(service, QStringList{QStringLiteral("context")});
+}
+
+QString TWApp::languageServiceStatusText() const
+{
+	const Tw::LanguageServiceSettings settings = languageServiceSettings();
+	if (!settings.enabled)
+		return tr("Language services are disabled.");
+	if (settings.executable.trimmed().isEmpty())
+		return tr("Choose a language server executable to use language services.");
+	using State = Tw::LanguageServices::LanguageService::State;
+	switch (m_languageServiceManager.state()) {
+		case State::Starting:
+		case State::Initializing:
+			return tr("Language server is starting.");
+		case State::Ready:
+			return tr("Language server is available.");
+		case State::Stopping:
+			return tr("Language server is stopping.");
+		case State::Failed:
+			return tr("Language server unavailable: %1").arg(
+			           m_languageServiceManager.service()->failureReason());
+		case State::NotConfigured:
+		case State::Stopped:
+		default:
+			return tr("Language server is not running.");
+	}
+}
+
+void TWApp::showPendingLanguageServiceNotice(QWidget * window)
+{
+	if (m_languageServiceNotice.isEmpty() || m_languageServiceNoticeShown)
+		return;
+	TeXDocumentWindow * sourceWindow = qobject_cast<TeXDocumentWindow *>(window);
+	if (!sourceWindow)
+		sourceWindow = qobject_cast<TeXDocumentWindow *>(topTeXWindow());
+	if (!sourceWindow)
+		return;
+	sourceWindow->statusBar()->showMessage(m_languageServiceNotice, 10000);
+	m_languageServiceNoticeShown = true;
 }
 
 // static

--- a/src/TWApp.h
+++ b/src/TWApp.h
@@ -44,6 +44,7 @@
 
 class Engine;
 class TWScriptManager;
+namespace Tw { struct LanguageServiceSettings; }
 
 #if defined(Q_OS_WIN)
 #define PATH_LIST_SEP   ";"
@@ -112,6 +113,9 @@ public:
 
 	Tw::Utils::TypesetManager & typesetManager() { return m_typesetManager; }
 	Tw::LanguageServices::LanguageServiceManager & languageServiceManager() { return m_languageServiceManager; }
+	Tw::LanguageServiceSettings languageServiceSettings() const;
+	void setLanguageServiceSettings(const Tw::LanguageServiceSettings & settings);
+	QString languageServiceStatusText() const;
 
 	TWScriptManager* getScriptManager() { return scriptManager; }
 
@@ -264,6 +268,8 @@ private:
 	void exitLater(int retCode);
 
 	void arrangeWindows(WindowArrangementFunction func);
+	void applyLanguageServiceSettings(const Tw::LanguageServiceSettings & settings);
+	void showPendingLanguageServiceNotice(QWidget * window = nullptr);
 
 	int recentFilesLimit{kDefaultMaxRecentFiles};
 
@@ -282,6 +288,8 @@ private:
 
 	Tw::Utils::TypesetManager m_typesetManager{this};
 	Tw::LanguageServices::LanguageServiceManager m_languageServiceManager{this};
+	QString m_languageServiceNotice;
+	bool m_languageServiceNoticeShown{false};
 
 	static TWApp *theAppInstance;
 	Tw::InterProcessCommunicator m_IPC;

--- a/src/TWApp.h
+++ b/src/TWApp.h
@@ -23,6 +23,7 @@
 #define TWApp_H
 
 #include "InterProcessCommunicator.h"
+#include "languageservices/LanguageServiceManager.h"
 #include "utils/TypesetManager.h"
 
 #include <QAction>
@@ -110,6 +111,7 @@ public:
 	static QStringList getTranslationList();
 
 	Tw::Utils::TypesetManager & typesetManager() { return m_typesetManager; }
+	Tw::LanguageServices::LanguageServiceManager & languageServiceManager() { return m_languageServiceManager; }
 
 	TWScriptManager* getScriptManager() { return scriptManager; }
 
@@ -279,6 +281,7 @@ private:
 	QHash<QString, QVariant> m_globals;
 
 	Tw::Utils::TypesetManager m_typesetManager{this};
+	Tw::LanguageServices::LanguageServiceManager m_languageServiceManager{this};
 
 	static TWApp *theAppInstance;
 	Tw::InterProcessCommunicator m_IPC;
@@ -303,4 +306,3 @@ public:
 };
 
 #endif	// TWApp_H
-

--- a/src/TWUtils.cpp
+++ b/src/TWUtils.cpp
@@ -21,6 +21,7 @@
 
 #include "TWUtils.h"
 
+#include "DefaultFileFilters.h"
 #include "PDFDocumentWindow.h"
 #include "Settings.h"
 #include "TWApp.h"
@@ -200,49 +201,13 @@ QStringList* TWUtils::filterList()
 
 void TWUtils::setDefaultFilters()
 {
-	*filters << QObject::tr("TeX documents (*.tex)");
-	*filters << QObject::tr("LaTeX documents (*.ltx)");
-	*filters << QObject::tr("Log files (*.log *.blg)");
-	*filters << QObject::tr("BibTeX databases (*.bib)");
-	*filters << QObject::tr("Style files (*.sty)");
-	*filters << QObject::tr("Class files (*.cls)");
-	*filters << QObject::tr("Documented macros (*.dtx)");
-	*filters << QObject::tr("Auxiliary files (*.aux *.toc *.lot *.lof *.nav *.out *.snm *.ind *.idx *.bbl *.brf)");
-	*filters << QObject::tr("Text files (*.txt)");
-	*filters << QObject::tr("PDF documents (*.pdf)");
-#ifdef Q_OS_WIN
-	// It seems (contrary to documentation) that on Windows, this has to be
-	// *.* to allow saving files with non-standard extensions (though *.* still
-	// does not allow to save without any extension at all, see below)
-	const QString allFilesFilter = QStringLiteral("*.*");
-//	const QString allFilesFilter = QStringLiteral("*");
-#else
-	// On other systems, *.* might require a . in the filename, which would
-	// preclude filenames without extension. In line with the documentation, *
-	// should be used in those cases
-	const QString allFilesFilter = QStringLiteral("*");
-#endif
-	*filters << QObject::tr("All files") + QStringLiteral(" (%1)").arg(allFilesFilter);
+	filters->append(Tw::DefaultFileFilters::filters());
 }
 
 /*static*/
 QString TWUtils::chooseDefaultFilter(const QString & filename, const QStringList & filters)
 {
-	QString extension = QFileInfo(filename).completeSuffix();
-
-	if (extension.isEmpty())
-		return filters.last();
-
-	foreach (QString filter, filters) {
-		// return filter if it corresponds to the given extension
-		// note that the extension must be the first one in the list to match;
-		// otherwise, the file dialog would replace the actual extension by the
-		// first one in the list, thereby altering it without cause
-		if (filter.contains(QString::fromLatin1("(*.%1").arg(extension)))
-			return filter;
-	}
-	// if no filter matched, return the last one (which should be "All files")
-	return filters.last();
+	return Tw::DefaultFileFilters::chooseForFile(filename, filters);
 }
 
 void TWUtils::updateRecentFileActions(QObject *parent, QList<QAction*> &actions, QMenu *menu, QAction * clearAction) /* static */

--- a/src/TeXDocumentWindow.cpp
+++ b/src/TeXDocumentWindow.cpp
@@ -36,6 +36,7 @@
 #include "scripting/ScriptAPI.h"
 #include "document/SpellChecker.h"
 #include "document/SpellCheckManager.h"
+#include "languageservices/LanguageServiceNavigation.h"
 #include "ui/ClickableLabel.h"
 #include "ui/RemoveAuxFilesDialog.h"
 #include "utils/CmdKeyFilter.h"
@@ -188,6 +189,7 @@ void TeXDocumentWindow::init()
 
 	connect(actionFont, &QAction::triggered, this, &TeXDocumentWindow::doFontDialog);
 	connect(actionGo_to_Line, &QAction::triggered, this, &TeXDocumentWindow::doLineDialog);
+	connect(actionGo_to_Definition, &QAction::triggered, this, &TeXDocumentWindow::goToDefinition);
 	connect(actionFind, &QAction::triggered, this, &TeXDocumentWindow::doFindDialog);
 	connect(actionFind_Again, &QAction::triggered, this, &TeXDocumentWindow::doFindAgain);
 	connect(actionReplace, &QAction::triggered, this, &TeXDocumentWindow::doReplaceDialog);
@@ -218,6 +220,9 @@ void TeXDocumentWindow::init()
 	connect(textDoc(), &Tw::Document::TeXDocument::modificationChanged, this, &TeXDocumentWindow::maybeEnableSaveAndRevert);
 	connect(textDoc(), &Tw::Document::TeXDocument::modelinesChanged, this, &TeXDocumentWindow::handleModelineChange);
 	connect(textEdit, &CompletingEdit::cursorPositionChanged, this, &TeXDocumentWindow::showCursorPosition);
+	connect(textEdit, &CompletingEdit::cursorPositionChanged, this, [this]() {
+		TWApp::instance()->languageServiceManager().cancelDefinitionRequest(textDoc());
+	});
 	connect(textEdit, &CompletingEdit::selectionChanged, this, &TeXDocumentWindow::showCursorPosition);
 	connect(textEdit, &CompletingEdit::syncClick, this, &TeXDocumentWindow::syncClick);
 	connect(this, &TeXDocumentWindow::syncFromSource, TWApp::instance(), &TWApp::syncPdf);
@@ -429,6 +434,39 @@ void TeXDocumentWindow::init()
 
 	TWUtils::insertHelpMenuItems(menuHelp);
 	TWUtils::installCustomShortcuts(this);
+	Tw::LanguageServices::LanguageServiceManager & languageServices = TWApp::instance()->languageServiceManager();
+	Tw::LanguageServices::LanguageServiceManager * languageServiceManager = &languageServices;
+	connect(textEdit, &CompletingEdit::completionRequested, this,
+	        [this, languageServiceManager](const Tw::LanguageServices::LanguagePosition & position) {
+		        languageServiceManager->requestCompletion(textDoc(), position);
+	        });
+	connect(textEdit, &CompletingEdit::completionContextInvalidated, this,
+	        [this, languageServiceManager]() { languageServiceManager->cancelCompletionRequest(textDoc()); });
+	connect(textEdit, &CompletingEdit::completionEditStarted, this,
+	        [this, languageServiceManager]() { languageServiceManager->beginCompletionEdit(textDoc()); });
+	connect(textEdit, &CompletingEdit::completionEditFinished, this,
+	        [this, languageServiceManager]() { languageServiceManager->endCompletionEdit(textDoc()); });
+	connect(&languageServices, &Tw::LanguageServices::LanguageServiceManager::completionAvailabilityChanged,
+	        this, [this](Tw::Document::TeXDocument * document, bool available) {
+		        if (document == textDoc())
+			        textEdit->setProviderCompletionAvailable(available);
+	        });
+	connect(&languageServices, &Tw::LanguageServices::LanguageServiceManager::completionReady,
+	        this, [this](Tw::Document::TeXDocument * document,
+	                     const QList<Tw::LanguageServices::CompletionItem> & items) {
+		        if (document == textDoc())
+			        textEdit->mergeProviderCompletions(items);
+	        });
+	connect(&languageServices, &Tw::LanguageServices::LanguageServiceManager::definitionAvailabilityChanged,
+	        this, [this](Tw::Document::TeXDocument * document, bool) {
+		        if (document == textDoc())
+			        updateDefinitionAction();
+	        });
+	connect(&languageServices, &Tw::LanguageServices::LanguageServiceManager::definitionReady,
+	        this, &TeXDocumentWindow::handleDefinitionResult);
+	languageServices.registerDocument(textDoc(), TWApp::instance()->getNamedEngine(engineName).sourceLanguage());
+	textEdit->setProviderCompletionAvailable(languageServices.canRequestCompletion(textDoc()));
+	updateDefinitionAction();
 	delayedInit();
 }
 
@@ -670,6 +708,29 @@ TeXDocumentWindow* TeXDocumentWindow::openDocument(const QString &fileName, bool
 	return doc;
 }
 
+TeXDocumentWindow * TeXDocumentWindow::openDocumentAtRange(const Tw::LanguageServices::LanguageLocation & location)
+{
+	if (!location.document.isLocalFile())
+		return nullptr;
+	const QFileInfo fileInfo(location.document.toLocalFile());
+	if (!fileInfo.exists() || !fileInfo.isFile())
+		return nullptr;
+	TeXDocumentWindow * document = findDocument(fileInfo.absoluteFilePath());
+	if (document) {
+		if (!document->goToRange(location.range))
+			return nullptr;
+	}
+	else {
+		if (!rangeIsValidInFile(fileInfo, location.range))
+			return nullptr;
+		document = openDocument(fileInfo.absoluteFilePath(), false, false);
+		if (!document || !document->goToRange(location.range))
+			return nullptr;
+	}
+	document->selectWindow();
+	return document;
+}
+
 void TeXDocumentWindow::closeEvent(QCloseEvent *event)
 {
 	if (process) {
@@ -690,6 +751,7 @@ void TeXDocumentWindow::closeEvent(QCloseEvent *event)
 	if (maybeSave()) {
 		event->accept();
 		saveRecentFileInfo();
+		TWApp::instance()->languageServiceManager().unregisterDocument(textDoc());
 		deleteLater();
 	}
 	else
@@ -951,7 +1013,9 @@ QTextCodec *TeXDocumentWindow::scanForEncoding(const QString &peekStr, bool &has
 QString TeXDocumentWindow::readFile(const QFileInfo & fileInfo,
 							  QTextCodec **codecUsed,
 							  int *lineEndings,
-							  QTextCodec * forceCodec)
+							  QTextCodec * forceCodec,
+							  bool *utf8BOM,
+							  QWidget *parent)
 	// reads the text from a file, after checking for %!TEX encoding.... metadata
 	// sets codecUsed to the QTextCodec used to read the text
 	// returns a null (not just empty) QString on failure
@@ -965,13 +1029,14 @@ QString TeXDocumentWindow::readFile(const QFileInfo & fileInfo,
 #endif
 	}
 
-	utf8BOM = false;
+	if (utf8BOM)
+		*utf8BOM = false;
 	QFile file(fileInfo.absoluteFilePath());
 	// Not using QFile::Text because this prevents us reading "classic" Mac files
 	// with CR-only line endings. See issue #242.
 	if (!file.open(QFile::ReadOnly)) {
-		QMessageBox::warning(this, QCoreApplication::applicationName(),
-							 tr("Cannot read file \"%1\":\n%2")
+		QMessageBox::warning(parent, QCoreApplication::applicationName(),
+							 TeXDocumentWindow::tr("Cannot read file \"%1\":\n%2")
 							 .arg(fileInfo.absoluteFilePath(), file.errorString()));
 		return QString();
 	}
@@ -987,8 +1052,8 @@ QString TeXDocumentWindow::readFile(const QFileInfo & fileInfo,
 		if (!(*codecUsed)) {
 			*codecUsed = TWApp::instance()->getDefaultCodec();
 			if (hasMetadata) {
-				if (QMessageBox::warning(this, tr("Unrecognized encoding"),
-						tr("The text encoding %1 used in %2 is not supported.\n\n"
+				if (QMessageBox::warning(parent, TeXDocumentWindow::tr("Unrecognized encoding"),
+						TeXDocumentWindow::tr("The text encoding %1 used in %2 is not supported.\n\n"
 						   "It will be interpreted as %3 instead, which may result in incorrect text.")
 							.arg(reqName, fileInfo.absoluteFilePath(), QString::fromUtf8((*codecUsed)->name().constData())),
 						QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Ok) == QMessageBox::Cancel)
@@ -1001,7 +1066,8 @@ QString TeXDocumentWindow::readFile(const QFileInfo & fileInfo,
 	// ignored during reading and not produced when writing. To keep them in
 	// files that have them, we need to check for them ourselves.
 	if ((*codecUsed)->mibEnum() == 106 && peekBytes.size() >= 3 && peekBytes[0] == '\xEF' && peekBytes[1] == '\xBB' && peekBytes[2] == '\xBF')
-		utf8BOM = true;
+		if (utf8BOM)
+			*utf8BOM = true;
 
 	// If the file is empty (we're already at the end), don't try to read
 	// anything using QTextStream below as that would return a Null-String
@@ -1033,9 +1099,22 @@ QString TeXDocumentWindow::readFile(const QFileInfo & fileInfo,
 	return text;
 }
 
+bool TeXDocumentWindow::rangeIsValidInFile(const QFileInfo &fileInfo,
+		const Tw::LanguageServices::LanguageRange &range)
+{
+	QTextCodec *codecUsed = nullptr;
+	const QString fileContents = readFile(fileInfo, &codecUsed);
+	if (fileContents.isNull())
+		return false;
+	QTextDocument document;
+	document.setPlainText(fileContents);
+	QTextCursor cursor;
+	return Tw::LanguageServices::cursorForLanguageRange(&document, range, cursor);
+}
+
 void TeXDocumentWindow::loadFile(const QFileInfo & fileInfo, bool asTemplate, bool inBackground, bool reload, QTextCodec * forceCodec)
 {
-	QString fileContents = readFile(fileInfo, &codec, &lineEndings, forceCodec);
+	QString fileContents = readFile(fileInfo, &codec, &lineEndings, forceCodec, &utf8BOM, this);
 	showLineEndingSetting();
 	showEncodingSetting();
 
@@ -1526,6 +1605,7 @@ void TeXDocumentWindow::setCurrentFile(const QFileInfo & fileInfo)
 	conditionallyEnableRemoveAuxFiles();
 
 	TWApp::instance()->updateWindowMenus();
+	TWApp::instance()->languageServiceManager().updateDocumentIdentity(textDoc());
 }
 
 void TeXDocumentWindow::saveRecentFileInfo()
@@ -1596,8 +1676,12 @@ void TeXDocumentWindow::updateEngineList()
 	int index = engine->findText(engineName, Qt::MatchFixedString);
 	if (index < 0)
 		index = engine->findText(TWApp::instance()->getDefaultEngine().name(), Qt::MatchFixedString);
-	if (index >= 0)
-		engine->setCurrentIndex(index);
+	if (index >= 0) {
+		if (engine->currentIndex() != index)
+			engine->setCurrentIndex(index);
+		else
+			selectedEngine(index);
+	}
 }
 
 void TeXDocumentWindow::selectedEngine(QAction* engineAction) // sent by actions in menubar menu; update toolbar combo box
@@ -1614,6 +1698,8 @@ void TeXDocumentWindow::selectedEngine(int idx) // sent by toolbar combo box; ne
 {
 	const QString name = engine->itemText(idx);
 	engineName = name;
+	TWApp::instance()->languageServiceManager().updateDocumentLanguageHint(
+	    textDoc(), TWApp::instance()->getNamedEngine(engineName).sourceLanguage());
 	foreach (QAction *act, engineActions->actions()) {
 		if (act->text() == name) {
 			act->setChecked(true);
@@ -1796,6 +1882,54 @@ void TeXDocumentWindow::goToLine(int lineNo, int selStart, int selEnd)
 		cursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
 	textEdit->setTextCursor(cursor);
 	maybeCenterSelection(oldScrollValue);
+}
+
+bool TeXDocumentWindow::goToRange(const Tw::LanguageServices::LanguageRange & range)
+{
+	QTextDocument * document = textEdit->document();
+	QTextCursor cursor;
+	if (!Tw::LanguageServices::cursorForLanguageRange(document, range, cursor))
+		return false;
+	int oldScrollValue = -1;
+	if (textEdit->verticalScrollBar())
+		oldScrollValue = textEdit->verticalScrollBar()->value();
+	textEdit->setTextCursor(cursor);
+	textEdit->ensureCursorVisible();
+	maybeCenterSelection(oldScrollValue);
+	return true;
+}
+
+void TeXDocumentWindow::goToDefinition()
+{
+	const QTextCursor cursor = textEdit->textCursor();
+	Tw::LanguageServices::LanguagePosition position;
+	position.line = cursor.blockNumber();
+	position.character = cursor.positionInBlock();
+	TWApp::instance()->languageServiceManager().requestDefinition(textDoc(), position);
+}
+
+void TeXDocumentWindow::updateDefinitionAction()
+{
+	actionGo_to_Definition->setEnabled(
+		TWApp::instance()->languageServiceManager().canRequestDefinition(textDoc()));
+}
+
+void TeXDocumentWindow::handleDefinitionResult(
+	Tw::Document::TeXDocument * document,
+	const QList<Tw::LanguageServices::LanguageLocation> & locations)
+{
+	if (document != textDoc())
+		return;
+	if (locations.isEmpty()) {
+		statusBar()->showMessage(tr("Definition not found"), kStatusMessageDuration);
+		return;
+	}
+	if (locations.size() != 1) {
+		statusBar()->showMessage(tr("Multiple definitions found"), kStatusMessageDuration);
+		return;
+	}
+	if (!openDocumentAtRange(locations.first()))
+		statusBar()->showMessage(tr("Cannot open definition location"), kStatusMessageDuration);
 }
 
 void TeXDocumentWindow::maybeCenterSelection(int oldScrollValue)

--- a/src/TeXDocumentWindow.h
+++ b/src/TeXDocumentWindow.h
@@ -26,6 +26,7 @@
 #include "FindDialog.h"
 #include "TWScriptableWindow.h"
 #include "document/TeXDocument.h"
+#include "languageservices/LanguageServiceTypes.h"
 #include "ui_TeXDocumentWindow.h"
 
 #include <QDateTime>
@@ -80,6 +81,7 @@ public:
 		}
 	static TeXDocumentWindow *openDocument(const QString &fileName, bool activate = true, bool raiseWindow = true,
 									 int lineNo = 0, int selStart = -1, int selEnd = -1);
+	static TeXDocumentWindow *openDocumentAtRange(const Tw::LanguageServices::LanguageLocation & location);
 
 	TeXDocumentWindow *open(const QString &fileName);
 	void makeUntitled();
@@ -108,6 +110,7 @@ public:
 		{ return pdfDoc; }
 
 	void goToLine(int lineNo, int selStart = -1, int selEnd = -1);
+	bool goToRange(const Tw::LanguageServices::LanguageRange & range);
 	void goToTag(int index);
 
 	bool isModified() const { return textEdit->document()->isModified(); }
@@ -163,6 +166,7 @@ public slots:
 	void doLineDialog();
 	void doFindDialog();
 	void doFindAgain(bool fromDialog = false);
+	void goToDefinition();
 	void doReplaceDialog();
 	void doReplaceAgain();
 	void doIndent();
@@ -224,6 +228,9 @@ private slots:
 	void encodingLabelClick(QMouseEvent * event) { encodingPopup(event->pos()); }
 	void anchorClicked(const QUrl& url);
 	void delayedInit();
+	void updateDefinitionAction();
+	void handleDefinitionResult(Tw::Document::TeXDocument * document,
+	                            const QList<Tw::LanguageServices::LanguageLocation> & locations);
 
 private:
 	void init();
@@ -231,8 +238,9 @@ private:
 	void detachPdf();
 	bool saveFilesHavingRoot(const QString& aRootFile);
 	void clearFileWatcher();
-	QTextCodec *scanForEncoding(const QString &peekStr, bool &hasMetadata, QString &reqName);
-	QString readFile(const QFileInfo & fileInfo, QTextCodec **codecUsed, int *lineEndings = nullptr, QTextCodec * forceCodec = nullptr);
+	static QTextCodec *scanForEncoding(const QString &peekStr, bool &hasMetadata, QString &reqName);
+	static QString readFile(const QFileInfo & fileInfo, QTextCodec **codecUsed, int *lineEndings = nullptr, QTextCodec * forceCodec = nullptr, bool *utf8BOM = nullptr, QWidget *parent = nullptr);
+	static bool rangeIsValidInFile(const QFileInfo &fileInfo, const Tw::LanguageServices::LanguageRange &range);
 	void loadFile(const QFileInfo & fileInfo, bool asTemplate = false, bool inBackground = false, bool reload = false, QTextCodec * forceCodec = nullptr);
 	bool saveFile(const QFileInfo & fileInfo);
 	void setCurrentFile(const QFileInfo & fileInfo);

--- a/src/TeXDocumentWindow.ui
+++ b/src/TeXDocumentWindow.ui
@@ -282,6 +282,7 @@
     <addaction name="actionCopy_to_Replace"/>
     <addaction name="actionFind_Selection"/>
     <addaction name="separator"/>
+    <addaction name="actionGo_to_Definition"/>
     <addaction name="actionGo_to_Line"/>
     <addaction name="actionShow_Selection"/>
    </widget>
@@ -680,6 +681,20 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+L</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::NoRole</enum>
+   </property>
+  </action>
+  <action name="actionGo_to_Definition">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Go to Definition</string>
+   </property>
+   <property name="shortcut">
+    <string>F12</string>
    </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>

--- a/src/document/TextDocument.cpp
+++ b/src/document/TextDocument.cpp
@@ -62,5 +62,29 @@ unsigned int TextDocument::removeTags(int offset, int len)
 	return removed;
 }
 
+QString TextDocument::canonicalText() const
+{
+#if QT_VERSION < QT_VERSION_CHECK(5, 9, 0)
+	return toPlainText();
+#else
+	QString text{toRawText()};
+	QChar * current = text.data();
+	QChar * end = current + text.size();
+	for (; current != end; ++current) {
+		switch (current->unicode()) {
+			case 0xfdd0:
+			case 0xfdd1:
+			case QChar::ParagraphSeparator:
+			case QChar::LineSeparator:
+				*current = QLatin1Char('\n');
+				break;
+			default:
+				break;
+		}
+	}
+	return text;
+#endif
+}
+
 } // namespace Document
 } // namespace Tw

--- a/src/document/TextDocument.h
+++ b/src/document/TextDocument.h
@@ -45,6 +45,7 @@ public:
 	const QList<Tag> & getTags() const { return _tags; }
 	void addTag(const QTextCursor & cursor, const unsigned int level, const QString & text);
 	unsigned int removeTags(int offset, int len);
+	QString canonicalText() const;
 
 signals:
 	void tagsChanged() const;

--- a/src/languageservices/LanguageService.cpp
+++ b/src/languageservices/LanguageService.cpp
@@ -1,0 +1,86 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+
+#include "languageservices/LanguageService.h"
+
+#include <atomic>
+
+namespace Tw {
+namespace LanguageServices {
+
+namespace {
+std::atomic<quint64> nextGeneration{1};
+}
+
+LanguageService::LanguageService(QObject * parent)
+	: QObject(parent)
+{
+}
+
+bool LanguageService::beginStart()
+{
+	if (m_state != Stopped)
+		return false;
+	m_failureReason.clear();
+	clearCapabilities();
+	m_generation = nextGeneration.fetch_add(1);
+	emit generationChanged(m_generation);
+	setState(Starting);
+	return true;
+}
+
+void LanguageService::setState(State state)
+{
+	if (m_state == state)
+		return;
+	const bool wasReady = isReady();
+	if (state != Ready)
+		clearCapabilities();
+	m_state = state;
+	emit stateChanged(m_state);
+	if (wasReady != isReady())
+		emit readinessChanged(isReady());
+}
+
+void LanguageService::becomeReady(const LanguageServiceCapabilities & capabilities)
+{
+	if (m_state != Initializing)
+		return;
+	m_capabilities = capabilities;
+	setState(Ready);
+	emit capabilitiesChanged(m_capabilities);
+}
+
+void LanguageService::becomeFailed(const QString & reason)
+{
+	if (m_state == Failed || m_state == Stopped)
+		return;
+	m_failureReason = reason;
+	setState(Failed);
+	emit failed(m_failureReason);
+}
+
+void LanguageService::becomeStopped()
+{
+	m_failureReason.clear();
+	setState(Stopped);
+}
+
+void LanguageService::clearCapabilities()
+{
+	const LanguageServiceCapabilities empty;
+	if (m_capabilities == empty)
+		return;
+	m_capabilities = empty;
+	emit capabilitiesChanged(m_capabilities);
+}
+
+} // namespace LanguageServices
+} // namespace Tw

--- a/src/languageservices/LanguageService.h
+++ b/src/languageservices/LanguageService.h
@@ -1,0 +1,76 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+#ifndef LANGUAGESERVICE_H
+#define LANGUAGESERVICE_H
+
+#include "languageservices/LanguageServiceTypes.h"
+
+#include <QObject>
+
+namespace Tw {
+namespace LanguageServices {
+
+class LanguageService : public QObject
+{
+	Q_OBJECT
+
+public:
+	enum State {
+		NotConfigured,
+		Starting,
+		Initializing,
+		Ready,
+		Stopping,
+		Failed,
+		Stopped
+	};
+	Q_ENUMS(State)
+
+	explicit LanguageService(QObject * parent = nullptr);
+	~LanguageService() override = default;
+
+	State state() const { return m_state; }
+	bool isReady() const { return m_state == Ready; }
+	LanguageServiceCapabilities capabilities() const { return m_capabilities; }
+	quint64 generation() const { return m_generation; }
+	QString failureReason() const { return m_failureReason; }
+
+	virtual bool start() = 0;
+	virtual void stop() = 0;
+
+signals:
+	void stateChanged(Tw::LanguageServices::LanguageService::State state);
+	void readinessChanged(bool ready);
+	void capabilitiesChanged(const Tw::LanguageServices::LanguageServiceCapabilities & capabilities);
+	void generationChanged(quint64 generation);
+	void failed(const QString & reason);
+
+protected:
+	bool beginStart();
+	void setState(State state);
+	void becomeReady(const LanguageServiceCapabilities & capabilities);
+	void becomeFailed(const QString & reason);
+	void becomeStopped();
+
+private:
+	void clearCapabilities();
+
+	State m_state{Stopped};
+	LanguageServiceCapabilities m_capabilities;
+	quint64 m_generation{0};
+	QString m_failureReason;
+};
+
+} // namespace LanguageServices
+} // namespace Tw
+
+Q_DECLARE_METATYPE(Tw::LanguageServices::LanguageService::State)
+
+#endif // LANGUAGESERVICE_H

--- a/src/languageservices/LanguageService.h
+++ b/src/languageservices/LanguageService.h
@@ -44,6 +44,11 @@ public:
 
 	virtual bool start() = 0;
 	virtual void stop() = 0;
+	virtual bool openDocument(const LanguageDocumentOpen & document) = 0;
+	virtual bool changeDocument(const QUrl & url, quint64 version, const LanguageDocumentChange & change) = 0;
+	virtual bool closeDocument(const QUrl & url) = 0;
+	virtual bool requestCompletion(const LanguageCompletionRequest & request) = 0;
+	virtual bool requestDefinition(const LanguageDefinitionRequest & request) = 0;
 
 signals:
 	void stateChanged(Tw::LanguageServices::LanguageService::State state);
@@ -51,6 +56,10 @@ signals:
 	void capabilitiesChanged(const Tw::LanguageServices::LanguageServiceCapabilities & capabilities);
 	void generationChanged(quint64 generation);
 	void failed(const QString & reason);
+	void completionFinished(quint64 token, const QList<Tw::LanguageServices::CompletionItem> & items);
+	void completionFailed(quint64 token, const QString & reason);
+	void definitionFinished(quint64 token, const QList<Tw::LanguageServices::LanguageLocation> & locations);
+	void definitionFailed(quint64 token, const QString & reason);
 
 protected:
 	bool beginStart();

--- a/src/languageservices/LanguageServiceConfiguration.h
+++ b/src/languageservices/LanguageServiceConfiguration.h
@@ -1,0 +1,31 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+#ifndef LANGUAGESERVICECONFIGURATION_H
+#define LANGUAGESERVICECONFIGURATION_H
+
+#include <QProcessEnvironment>
+#include <QString>
+#include <QStringList>
+
+namespace Tw {
+namespace LanguageServices {
+
+struct LanguageServiceConfiguration
+{
+	QString executable;
+	QStringList arguments;
+	QProcessEnvironment environment{QProcessEnvironment::systemEnvironment()};
+	QString workingDirectory;
+};
+
+} // namespace LanguageServices
+} // namespace Tw
+
+#endif // LANGUAGESERVICECONFIGURATION_H

--- a/src/languageservices/LanguageServiceDocumentBinding.cpp
+++ b/src/languageservices/LanguageServiceDocumentBinding.cpp
@@ -1,0 +1,358 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+
+#include "languageservices/LanguageServiceDocumentBinding.h"
+
+#include "document/TeXDocument.h"
+
+#include <QTextBlock>
+
+#include <atomic>
+
+namespace Tw {
+namespace LanguageServices {
+
+namespace {
+std::atomic<quint64> nextCompletionToken{1};
+std::atomic<quint64> nextDefinitionToken{1};
+}
+
+LanguageServiceDocumentBinding::LanguageServiceDocumentBinding(Document::TeXDocument * document,
+	                                                             LanguageService * service, QObject * parent)
+	: QObject(parent), m_document(document), m_service(service)
+{
+	Q_ASSERT(document);
+	Q_ASSERT(service);
+	// QTextDocument only emits granular contentsChange notifications once it
+	// has a layout. Editors normally provide one; bindings also make the
+	// requirement explicit for non-widget document users and tests.
+	document->documentLayout();
+	connect(document, &QTextDocument::contentsChange, this, &LanguageServiceDocumentBinding::handleContentsChange);
+	connect(service, &LanguageService::stateChanged, this, &LanguageServiceDocumentBinding::handleServiceState);
+	connect(service, &LanguageService::generationChanged, this, [this](quint64) { deactivate(false); });
+	connect(service, &LanguageService::capabilitiesChanged, this,
+	        [this](const LanguageServiceCapabilities &) {
+		        updateCompletionAvailability();
+		        updateDefinitionAvailability();
+	        });
+	connect(service, &LanguageService::completionFinished, this,
+	        &LanguageServiceDocumentBinding::handleCompletionResult);
+	connect(service, &LanguageService::completionFailed, this,
+	        [this](quint64 token, const QString &) {
+		        if (token == m_completionToken) {
+			        cancelCompletionRequest();
+			        emit completionReady({});
+		        }
+	        });
+	connect(service, &LanguageService::definitionFinished, this,
+	        &LanguageServiceDocumentBinding::handleDefinitionResult);
+	connect(service, &LanguageService::definitionFailed, this,
+	        [this](quint64 token, const QString &) {
+		        if (token == m_definitionToken)
+			        cancelDefinitionRequest();
+	        });
+}
+
+void LanguageServiceDocumentBinding::updateIdentity(const QUrl & url, const QString & languageId)
+{
+	if (m_closed || (m_url == url && m_languageId == languageId))
+		return;
+	deactivate(true);
+	m_url = url;
+	m_languageId = languageId;
+	++m_identityGeneration;
+	m_version = 0;
+	m_shadow.clear();
+	activate();
+	updateCompletionAvailability();
+	updateDefinitionAvailability();
+}
+
+void LanguageServiceDocumentBinding::prepareServiceStop()
+{
+	deactivate(true);
+}
+
+void LanguageServiceDocumentBinding::close()
+{
+	if (m_closed)
+		return;
+	m_closed = true;
+	m_completionEditDepth = 0;
+	cancelCompletionRequest();
+	cancelDefinitionRequest();
+	deactivate(true);
+	++m_identityGeneration;
+	disconnect(this);
+	if (m_document)
+		disconnect(m_document, nullptr, this, nullptr);
+	if (m_service)
+		disconnect(m_service, nullptr, this, nullptr);
+}
+
+bool LanguageServiceDocumentBinding::canRequestCompletion() const
+{
+	if (m_closed || !m_document || !m_service || !m_service->isReady()
+	    || !m_service->capabilities().completion || !m_synchronized
+	    || m_serviceGeneration != m_service->generation() || m_url.isEmpty()
+	    || m_languageId.isEmpty())
+		return false;
+	return !m_service->capabilities().openClose || m_openOnServer;
+}
+
+bool LanguageServiceDocumentBinding::requestCompletion(const LanguagePosition & position)
+{
+	cancelCompletionRequest();
+	if (!canRequestCompletion() || !isPositionValid(position))
+		return false;
+	LanguageCompletionRequest request;
+	request.token = nextCompletionToken.fetch_add(1);
+	request.document = m_url;
+	request.synchronizedVersion = m_version;
+	request.position = position;
+	m_completionToken = request.token;
+	m_completionServiceGeneration = m_serviceGeneration;
+	m_completionIdentityGeneration = m_identityGeneration;
+	m_completionVersion = m_version;
+	if (!m_service->requestCompletion(request)) {
+		cancelCompletionRequest();
+		return false;
+	}
+	return true;
+}
+
+void LanguageServiceDocumentBinding::cancelCompletionRequest()
+{
+	if (m_completionEditDepth > 0)
+		return;
+	m_completionToken = 0;
+	m_completionServiceGeneration = 0;
+	m_completionIdentityGeneration = 0;
+	m_completionVersion = 0;
+}
+
+void LanguageServiceDocumentBinding::beginCompletionEdit()
+{
+	++m_completionEditDepth;
+}
+
+void LanguageServiceDocumentBinding::endCompletionEdit()
+{
+	if (m_completionEditDepth > 0)
+		--m_completionEditDepth;
+}
+
+bool LanguageServiceDocumentBinding::canRequestDefinition() const
+{
+	if (m_closed || !m_document || !m_service || !m_service->isReady()
+	    || !m_service->capabilities().definition || !m_synchronized
+	    || m_serviceGeneration != m_service->generation() || m_url.isEmpty()
+	    || m_languageId.isEmpty())
+		return false;
+	return !m_service->capabilities().openClose || m_openOnServer;
+}
+
+bool LanguageServiceDocumentBinding::requestDefinition(const LanguagePosition & position)
+{
+	cancelDefinitionRequest();
+	if (!canRequestDefinition() || !isPositionValid(position))
+		return false;
+
+	LanguageDefinitionRequest request;
+	request.token = nextDefinitionToken.fetch_add(1);
+	request.document = m_url;
+	request.synchronizedVersion = m_version;
+	request.position = position;
+	m_definitionToken = request.token;
+	m_definitionServiceGeneration = m_serviceGeneration;
+	m_definitionIdentityGeneration = m_identityGeneration;
+	m_definitionVersion = m_version;
+	if (!m_service->requestDefinition(request)) {
+		cancelDefinitionRequest();
+		return false;
+	}
+	return true;
+}
+
+void LanguageServiceDocumentBinding::cancelDefinitionRequest()
+{
+	m_definitionToken = 0;
+	m_definitionServiceGeneration = 0;
+	m_definitionIdentityGeneration = 0;
+	m_definitionVersion = 0;
+}
+
+bool LanguageServiceDocumentBinding::isPositionValid(const LanguagePosition & position) const
+{
+	if (!m_document || position.line < 0 || position.character < 0)
+		return false;
+	const QTextBlock block = m_document->findBlockByNumber(position.line);
+	return block.isValid() && position.character <= block.text().size();
+}
+
+LanguagePosition LanguageServiceDocumentBinding::positionInText(const QString & text, int offset)
+{
+	const int textSize = static_cast<int>(text.size());
+	offset = qBound(0, offset, textSize);
+	LanguagePosition result;
+	int lineStart = 0;
+	for (int index = 0; index < offset; ++index) {
+		if (text.at(index) == QLatin1Char('\n')) {
+			++result.line;
+			lineStart = index + 1;
+		}
+	}
+	result.character = offset - lineStart;
+	return result;
+}
+
+void LanguageServiceDocumentBinding::handleContentsChange(int position, int charsRemoved, int charsAdded)
+{
+	if (m_completionEditDepth == 0)
+		cancelCompletionRequest();
+	cancelDefinitionRequest();
+	if (!m_synchronized || !m_document || !m_service || !m_service->isReady()
+	    || m_serviceGeneration != m_service->generation())
+		return;
+
+	const TextSyncKind syncKind = m_service->capabilities().textSync;
+	if (syncKind == TextSyncKind::None)
+		return;
+
+	const QString currentText = m_document->canonicalText();
+	LanguageDocumentChange change;
+	if (syncKind == TextSyncKind::Full) {
+		change.text = currentText;
+	}
+	else {
+		const int shadowSize = static_cast<int>(m_shadow.size());
+		const int boundedPosition = qBound(0, position, shadowSize);
+		const int boundedRemoved = qBound(0, charsRemoved, shadowSize - boundedPosition);
+		change.hasRange = true;
+		change.range.start = positionInText(m_shadow, boundedPosition);
+		change.range.end = positionInText(m_shadow, boundedPosition + boundedRemoved);
+		change.text = currentText.mid(boundedPosition, charsAdded);
+		QString updatedShadow = m_shadow;
+		updatedShadow.replace(boundedPosition, boundedRemoved, change.text);
+		if (updatedShadow != currentText) {
+			change.range.start = positionInText(m_shadow, 0);
+			change.range.end = positionInText(m_shadow, shadowSize);
+			change.text = currentText;
+		}
+		m_shadow = currentText;
+		Q_ASSERT(m_shadow == m_document->canonicalText());
+	}
+
+	++m_version;
+	if (m_completionEditDepth > 0 && m_completionToken != 0)
+		m_completionVersion = m_version;
+	if (!m_service->changeDocument(m_url, m_version, change))
+		deactivate(false);
+}
+
+void LanguageServiceDocumentBinding::handleServiceState(LanguageService::State state)
+{
+	if (state == LanguageService::Ready)
+		activate();
+	else
+		deactivate(false);
+	updateCompletionAvailability();
+	updateDefinitionAvailability();
+}
+
+void LanguageServiceDocumentBinding::handleCompletionResult(quint64 token, const QList<CompletionItem> & items)
+{
+	if (token == 0 || token != m_completionToken || !canRequestCompletion()
+	    || m_completionServiceGeneration != m_serviceGeneration
+	    || m_completionIdentityGeneration != m_identityGeneration
+	    || m_completionVersion != m_version)
+		return;
+	m_completionToken = 0;
+	m_completionServiceGeneration = 0;
+	m_completionIdentityGeneration = 0;
+	m_completionVersion = 0;
+	emit completionReady(items);
+}
+
+void LanguageServiceDocumentBinding::handleDefinitionResult(quint64 token, const QList<LanguageLocation> & locations)
+{
+	if (token == 0 || token != m_definitionToken || !canRequestDefinition()
+	    || m_definitionServiceGeneration != m_serviceGeneration
+	    || m_definitionIdentityGeneration != m_identityGeneration
+	    || m_definitionVersion != m_version)
+		return;
+	cancelDefinitionRequest();
+	emit definitionReady(locations);
+}
+
+void LanguageServiceDocumentBinding::activate()
+{
+	if (m_closed || m_synchronized || !m_document || !m_service || !m_service->isReady()
+	    || m_url.isEmpty() || m_languageId.isEmpty())
+		return;
+
+	m_serviceGeneration = m_service->generation();
+	m_version = 1;
+	const QString text = m_document->canonicalText();
+	if (m_service->capabilities().textSync == TextSyncKind::Incremental)
+		m_shadow = text;
+	else
+		m_shadow.clear();
+	m_synchronized = true;
+	if (m_service->capabilities().openClose) {
+		LanguageDocumentOpen document;
+		document.url = m_url;
+		document.languageId = m_languageId;
+		document.version = m_version;
+		document.text = text;
+		m_openOnServer = m_service->openDocument(document);
+		if (!m_openOnServer)
+			deactivate(false);
+	}
+	updateDefinitionAvailability();
+	updateCompletionAvailability();
+}
+
+void LanguageServiceDocumentBinding::deactivate(bool notifyClose)
+{
+	m_completionEditDepth = 0;
+	cancelCompletionRequest();
+	cancelDefinitionRequest();
+	if (notifyClose && m_openOnServer && m_service && m_service->isReady()
+	    && m_serviceGeneration == m_service->generation())
+		m_service->closeDocument(m_url);
+	m_synchronized = false;
+	m_openOnServer = false;
+	m_serviceGeneration = 0;
+	m_shadow.clear();
+	updateDefinitionAvailability();
+	updateCompletionAvailability();
+}
+
+void LanguageServiceDocumentBinding::updateCompletionAvailability()
+{
+	const bool available = canRequestCompletion();
+	if (available == m_completionAvailable)
+		return;
+	m_completionAvailable = available;
+	emit completionAvailabilityChanged(available);
+}
+
+void LanguageServiceDocumentBinding::updateDefinitionAvailability()
+{
+	const bool available = canRequestDefinition();
+	if (available == m_definitionAvailable)
+		return;
+	m_definitionAvailable = available;
+	emit definitionAvailabilityChanged(available);
+}
+
+} // namespace LanguageServices
+} // namespace Tw

--- a/src/languageservices/LanguageServiceDocumentBinding.h
+++ b/src/languageservices/LanguageServiceDocumentBinding.h
@@ -1,0 +1,94 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+#ifndef LANGUAGESERVICEDOCUMENTBINDING_H
+#define LANGUAGESERVICEDOCUMENTBINDING_H
+
+#include "languageservices/LanguageService.h"
+
+#include <QPointer>
+
+namespace Tw {
+namespace Document { class TeXDocument; }
+namespace LanguageServices {
+
+class LanguageServiceDocumentBinding : public QObject
+{
+	Q_OBJECT
+
+public:
+	LanguageServiceDocumentBinding(Document::TeXDocument * document, LanguageService * service, QObject * parent = nullptr);
+
+	void updateIdentity(const QUrl & url, const QString & languageId);
+	void prepareServiceStop();
+	void close();
+	bool canRequestCompletion() const;
+	bool requestCompletion(const LanguagePosition & position);
+	void cancelCompletionRequest();
+	void beginCompletionEdit();
+	void endCompletionEdit();
+	bool canRequestDefinition() const;
+	bool requestDefinition(const LanguagePosition & position);
+	void cancelDefinitionRequest();
+
+	QUrl url() const { return m_url; }
+	QString languageId() const { return m_languageId; }
+	quint64 version() const { return m_version; }
+	quint64 identityGeneration() const { return m_identityGeneration; }
+	quint64 serviceGeneration() const { return m_serviceGeneration; }
+	bool isSynchronized() const { return m_synchronized; }
+	bool isOpenOnServer() const { return m_openOnServer; }
+	QString shadow() const { return m_shadow; }
+
+signals:
+	void completionAvailabilityChanged(bool available);
+	void completionReady(const QList<Tw::LanguageServices::CompletionItem> & items);
+	void definitionAvailabilityChanged(bool available);
+	void definitionReady(const QList<Tw::LanguageServices::LanguageLocation> & locations);
+
+private:
+	static LanguagePosition positionInText(const QString & text, int offset);
+	void handleContentsChange(int position, int charsRemoved, int charsAdded);
+	void handleServiceState(LanguageService::State state);
+	void handleCompletionResult(quint64 token, const QList<CompletionItem> & items);
+	void handleDefinitionResult(quint64 token, const QList<LanguageLocation> & locations);
+	void activate();
+	void deactivate(bool notifyClose);
+	void updateCompletionAvailability();
+	void updateDefinitionAvailability();
+	bool isPositionValid(const LanguagePosition & position) const;
+
+	QPointer<Document::TeXDocument> m_document;
+	QPointer<LanguageService> m_service;
+	QUrl m_url;
+	QString m_languageId;
+	QString m_shadow;
+	quint64 m_version{0};
+	quint64 m_identityGeneration{0};
+	quint64 m_serviceGeneration{0};
+	quint64 m_completionToken{0};
+	quint64 m_completionServiceGeneration{0};
+	quint64 m_completionIdentityGeneration{0};
+	quint64 m_completionVersion{0};
+	quint64 m_definitionToken{0};
+	quint64 m_definitionServiceGeneration{0};
+	quint64 m_definitionIdentityGeneration{0};
+	quint64 m_definitionVersion{0};
+	bool m_synchronized{false};
+	bool m_openOnServer{false};
+	bool m_closed{false};
+	bool m_completionAvailable{false};
+	bool m_definitionAvailable{false};
+	int m_completionEditDepth{0};
+};
+
+} // namespace LanguageServices
+} // namespace Tw
+
+#endif // LANGUAGESERVICEDOCUMENTBINDING_H

--- a/src/languageservices/LanguageServiceManager.cpp
+++ b/src/languageservices/LanguageServiceManager.cpp
@@ -10,12 +10,21 @@
 
 #include "languageservices/LanguageServiceManager.h"
 
+#include "document/TeXDocument.h"
+#include "languageservices/LanguageServiceDocumentBinding.h"
+
+#include <QFileInfo>
+#include <QUrl>
+
 namespace Tw {
 namespace LanguageServices {
 
 LanguageServiceManager::LanguageServiceManager(QObject * parent)
-	: QObject(parent)
+	: QObject(parent), m_deferredRefreshTimer(this)
 {
+	m_deferredRefreshTimer.setSingleShot(true);
+	connect(&m_deferredRefreshTimer, &QTimer::timeout,
+	        this, &LanguageServiceManager::refreshPendingDocuments);
 }
 
 LanguageServiceManager::~LanguageServiceManager()
@@ -23,15 +32,16 @@ LanguageServiceManager::~LanguageServiceManager()
 	stop();
 }
 
-bool LanguageServiceManager::setService(LanguageService * service)
+bool LanguageServiceManager::setService(LanguageService * service, const QStringList & supportedLanguages)
 {
 	if (service == nullptr || m_service != nullptr || m_replacingService || service->parent() != nullptr)
 		return false;
-	installService(service);
+	installService(service, supportedLanguages);
 	return true;
 }
 
-bool LanguageServiceManager::replaceService(LanguageService * service, bool startService)
+bool LanguageServiceManager::replaceService(LanguageService * service, const QStringList & supportedLanguages,
+                                             bool startService)
 {
 	if (service && service == m_pendingService)
 		return true;
@@ -42,6 +52,7 @@ bool LanguageServiceManager::replaceService(LanguageService * service, bool star
 	m_pendingService = service;
 	if (m_pendingService)
 		m_pendingService->setParent(this);
+	m_pendingSupportedLanguages = supportedLanguages;
 	m_startPendingService = startService && service;
 
 	if (!m_service) {
@@ -52,6 +63,11 @@ bool LanguageServiceManager::replaceService(LanguageService * service, bool star
 		return true;
 
 	m_replacingService = true;
+	for (LanguageServiceDocumentBinding * binding : m_bindings) {
+		binding->prepareServiceStop();
+		delete binding;
+	}
+	m_bindings.clear();
 	LanguageService * previousService = m_service;
 	previousService->stop();
 	if (m_replacingService && previousService->state() == LanguageService::Stopped)
@@ -59,9 +75,10 @@ bool LanguageServiceManager::replaceService(LanguageService * service, bool star
 	return true;
 }
 
-void LanguageServiceManager::installService(LanguageService * service)
+void LanguageServiceManager::installService(LanguageService * service, const QStringList & supportedLanguages)
 {
 	m_service = service;
+	m_supportedLanguages = supportedLanguages;
 	m_service->setParent(this);
 	connect(m_service, &LanguageService::stateChanged, this,
 	        [this, service](LanguageService::State state) {
@@ -74,12 +91,15 @@ void LanguageServiceManager::installService(LanguageService * service)
 	connect(m_service, &LanguageService::capabilitiesChanged, this, &LanguageServiceManager::capabilitiesChanged);
 	connect(m_service, &LanguageService::failed, this, &LanguageServiceManager::failed);
 	emit serviceChanged(m_service);
+	for (Document::TeXDocument * document : m_documents.keys())
+		createBinding(document);
 }
 
 void LanguageServiceManager::finishServiceReplacement()
 {
 	LanguageService * previousService = m_service;
 	m_service = nullptr;
+	m_supportedLanguages.clear();
 	m_replacingService = false;
 	if (previousService) {
 		disconnect(previousService, nullptr, this, nullptr);
@@ -88,12 +108,14 @@ void LanguageServiceManager::finishServiceReplacement()
 	}
 
 	LanguageService * service = m_pendingService;
+	const QStringList supportedLanguages = m_pendingSupportedLanguages;
 	const bool startService = m_startPendingService;
 	m_pendingService = nullptr;
+	m_pendingSupportedLanguages.clear();
 	m_startPendingService = false;
 	if (!service)
 		return;
-	installService(service);
+	installService(service, supportedLanguages);
 	if (startService)
 		start();
 }
@@ -118,11 +140,194 @@ void LanguageServiceManager::stop()
 	if (m_pendingService) {
 		delete m_pendingService;
 		m_pendingService = nullptr;
+		m_pendingSupportedLanguages.clear();
 		m_startPendingService = false;
 	}
 	m_replacingService = false;
+	for (LanguageServiceDocumentBinding * binding : m_bindings)
+		binding->prepareServiceStop();
 	if (m_service)
 		m_service->stop();
+}
+
+void LanguageServiceManager::registerDocument(Document::TeXDocument * document, const QString & sourceLanguage)
+{
+	if (!document || m_documents.contains(document))
+		return;
+	m_documents.insert(document, sourceLanguage);
+	connect(document, &Document::TeXDocument::modelinesChanged, this,
+	        [this, document](const QStringList &, const QStringList &) {
+		        scheduleDocumentRefresh(document);
+	        });
+	connect(document, &QObject::destroyed, this, [this, document]() { unregisterDocument(document); });
+	createBinding(document);
+}
+
+void LanguageServiceManager::unregisterDocument(Document::TeXDocument * document)
+{
+	for (int i = static_cast<int>(m_pendingDocumentRefreshes.size()); i-- > 0;) {
+		if (!m_pendingDocumentRefreshes.at(i) || m_pendingDocumentRefreshes.at(i).data() == document)
+			m_pendingDocumentRefreshes.removeAt(i);
+	}
+	LanguageServiceDocumentBinding * binding = m_bindings.take(document);
+	if (binding) {
+		binding->close();
+		delete binding;
+	}
+	m_documents.remove(document);
+}
+
+void LanguageServiceManager::updateDocumentIdentity(Document::TeXDocument * document)
+{
+	refreshBinding(document);
+}
+
+void LanguageServiceManager::updateDocumentLanguageHint(Document::TeXDocument * document, const QString & sourceLanguage)
+{
+	if (!m_documents.contains(document))
+		return;
+	m_documents[document] = sourceLanguage;
+	refreshBinding(document);
+}
+
+LanguageServiceDocumentBinding * LanguageServiceManager::bindingForDocument(Document::TeXDocument * document) const
+{
+	return m_bindings.value(document, nullptr);
+}
+
+bool LanguageServiceManager::canRequestCompletion(Document::TeXDocument * document) const
+{
+	LanguageServiceDocumentBinding * binding = bindingForDocument(document);
+	return binding && binding->canRequestCompletion();
+}
+
+bool LanguageServiceManager::requestCompletion(Document::TeXDocument * document, const LanguagePosition & position)
+{
+	LanguageServiceDocumentBinding * binding = bindingForDocument(document);
+	return binding && binding->requestCompletion(position);
+}
+
+void LanguageServiceManager::cancelCompletionRequest(Document::TeXDocument * document)
+{
+	LanguageServiceDocumentBinding * binding = bindingForDocument(document);
+	if (binding)
+		binding->cancelCompletionRequest();
+}
+
+void LanguageServiceManager::beginCompletionEdit(Document::TeXDocument * document)
+{
+	LanguageServiceDocumentBinding * binding = bindingForDocument(document);
+	if (binding)
+		binding->beginCompletionEdit();
+}
+
+void LanguageServiceManager::endCompletionEdit(Document::TeXDocument * document)
+{
+	LanguageServiceDocumentBinding * binding = bindingForDocument(document);
+	if (binding)
+		binding->endCompletionEdit();
+}
+
+bool LanguageServiceManager::canRequestDefinition(Document::TeXDocument * document) const
+{
+	LanguageServiceDocumentBinding * binding = bindingForDocument(document);
+	return binding && binding->canRequestDefinition();
+}
+
+bool LanguageServiceManager::requestDefinition(Document::TeXDocument * document, const LanguagePosition & position)
+{
+	LanguageServiceDocumentBinding * binding = bindingForDocument(document);
+	return binding && binding->requestDefinition(position);
+}
+
+void LanguageServiceManager::cancelDefinitionRequest(Document::TeXDocument * document)
+{
+	LanguageServiceDocumentBinding * binding = bindingForDocument(document);
+	if (binding)
+		binding->cancelDefinitionRequest();
+}
+
+bool LanguageServiceManager::isSourceEligible(const Document::TeXDocument * document)
+{
+	return document && document->isStoredInFilesystem() && !document->absoluteFilePath().isEmpty();
+}
+
+QString LanguageServiceManager::identifyLanguageId(const Document::TeXDocument * document, const QString & sourceLanguage)
+{
+	if (!document)
+		return {};
+	const QString suffix = document->getFileInfo().suffix().toLower();
+	if (suffix == QStringLiteral("mkxl") || suffix == QStringLiteral("mkiv"))
+		return QStringLiteral("context");
+	if (suffix != QStringLiteral("tex"))
+		return {};
+
+	if (document->hasModeLine(QStringLiteral("program"))) {
+		return document->getModeLineValue(QStringLiteral("program")).trimmed().compare(
+		           QStringLiteral("context"), Qt::CaseInsensitive) == 0
+		           ? QStringLiteral("context")
+		           : QString{};
+	}
+	return sourceLanguage == QStringLiteral("context") ? QStringLiteral("context") : QString{};
+}
+
+void LanguageServiceManager::createBinding(Document::TeXDocument * document)
+{
+	if (!document || !m_service || m_bindings.contains(document))
+		return;
+	LanguageServiceDocumentBinding * binding = new LanguageServiceDocumentBinding(document, m_service, this);
+	m_bindings.insert(document, binding);
+	connect(binding, &LanguageServiceDocumentBinding::completionAvailabilityChanged, this,
+	        [this, document](bool available) { emit completionAvailabilityChanged(document, available); });
+	connect(binding, &LanguageServiceDocumentBinding::completionReady, this,
+	        [this, document](const QList<CompletionItem> & items) { emit completionReady(document, items); });
+	connect(binding, &LanguageServiceDocumentBinding::definitionAvailabilityChanged, this,
+	        [this, document](bool available) { emit definitionAvailabilityChanged(document, available); });
+	connect(binding, &LanguageServiceDocumentBinding::definitionReady, this,
+	        [this, document](const QList<LanguageLocation> & locations) { emit definitionReady(document, locations); });
+	refreshBinding(document);
+}
+
+void LanguageServiceManager::scheduleDocumentRefresh(Document::TeXDocument * document)
+{
+	if (!document || !m_documents.contains(document))
+		return;
+	for (const QPointer<Document::TeXDocument> & pendingDocument : m_pendingDocumentRefreshes) {
+		if (pendingDocument.data() == document)
+			return;
+	}
+	m_pendingDocumentRefreshes.append(QPointer<Document::TeXDocument>(document));
+	if (!m_deferredRefreshTimer.isActive())
+		m_deferredRefreshTimer.start(0);
+}
+
+void LanguageServiceManager::refreshPendingDocuments()
+{
+	const QList<QPointer<Document::TeXDocument>> pendingDocuments = m_pendingDocumentRefreshes;
+	m_pendingDocumentRefreshes.clear();
+	for (const QPointer<Document::TeXDocument> & document : pendingDocuments) {
+		if (document && m_documents.contains(document.data()))
+			refreshBinding(document.data());
+	}
+}
+
+void LanguageServiceManager::refreshBinding(Document::TeXDocument * document)
+{
+	LanguageServiceDocumentBinding * binding = m_bindings.value(document, nullptr);
+	if (!binding || !document)
+		return;
+	QString languageId;
+	if (isSourceEligible(document))
+		languageId = identifyLanguageId(document, m_documents.value(document));
+	if (!m_supportedLanguages.contains(languageId))
+		languageId.clear();
+	QUrl url;
+	if (!languageId.isEmpty()) {
+		const QFileInfo info(document->absoluteFilePath());
+		const QString path = info.canonicalFilePath().isEmpty() ? info.absoluteFilePath() : info.canonicalFilePath();
+		url = QUrl::fromLocalFile(path);
+	}
+	binding->updateIdentity(url, languageId);
 }
 
 } // namespace LanguageServices

--- a/src/languageservices/LanguageServiceManager.cpp
+++ b/src/languageservices/LanguageServiceManager.cpp
@@ -1,0 +1,129 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+
+#include "languageservices/LanguageServiceManager.h"
+
+namespace Tw {
+namespace LanguageServices {
+
+LanguageServiceManager::LanguageServiceManager(QObject * parent)
+	: QObject(parent)
+{
+}
+
+LanguageServiceManager::~LanguageServiceManager()
+{
+	stop();
+}
+
+bool LanguageServiceManager::setService(LanguageService * service)
+{
+	if (service == nullptr || m_service != nullptr || m_replacingService || service->parent() != nullptr)
+		return false;
+	installService(service);
+	return true;
+}
+
+bool LanguageServiceManager::replaceService(LanguageService * service, bool startService)
+{
+	if (service && service == m_pendingService)
+		return true;
+	if ((service && service->parent()) || service == m_service)
+		return false;
+	if (m_pendingService)
+		delete m_pendingService;
+	m_pendingService = service;
+	if (m_pendingService)
+		m_pendingService->setParent(this);
+	m_startPendingService = startService && service;
+
+	if (!m_service) {
+		finishServiceReplacement();
+		return true;
+	}
+	if (m_replacingService)
+		return true;
+
+	m_replacingService = true;
+	LanguageService * previousService = m_service;
+	previousService->stop();
+	if (m_replacingService && previousService->state() == LanguageService::Stopped)
+		finishServiceReplacement();
+	return true;
+}
+
+void LanguageServiceManager::installService(LanguageService * service)
+{
+	m_service = service;
+	m_service->setParent(this);
+	connect(m_service, &LanguageService::stateChanged, this,
+	        [this, service](LanguageService::State state) {
+		        if (service != m_service)
+			        return;
+		        emit stateChanged(state);
+		        if (m_replacingService && state == LanguageService::Stopped)
+			        finishServiceReplacement();
+	        });
+	connect(m_service, &LanguageService::capabilitiesChanged, this, &LanguageServiceManager::capabilitiesChanged);
+	connect(m_service, &LanguageService::failed, this, &LanguageServiceManager::failed);
+	emit serviceChanged(m_service);
+}
+
+void LanguageServiceManager::finishServiceReplacement()
+{
+	LanguageService * previousService = m_service;
+	m_service = nullptr;
+	m_replacingService = false;
+	if (previousService) {
+		disconnect(previousService, nullptr, this, nullptr);
+		previousService->deleteLater();
+		emit serviceChanged(nullptr);
+	}
+
+	LanguageService * service = m_pendingService;
+	const bool startService = m_startPendingService;
+	m_pendingService = nullptr;
+	m_startPendingService = false;
+	if (!service)
+		return;
+	installService(service);
+	if (startService)
+		start();
+}
+
+LanguageService::State LanguageServiceManager::state() const
+{
+	return m_service ? m_service->state() : LanguageService::NotConfigured;
+}
+
+LanguageServiceCapabilities LanguageServiceManager::capabilities() const
+{
+	return m_service ? m_service->capabilities() : LanguageServiceCapabilities{};
+}
+
+bool LanguageServiceManager::start()
+{
+	return m_service && m_service->start();
+}
+
+void LanguageServiceManager::stop()
+{
+	if (m_pendingService) {
+		delete m_pendingService;
+		m_pendingService = nullptr;
+		m_startPendingService = false;
+	}
+	m_replacingService = false;
+	if (m_service)
+		m_service->stop();
+}
+
+} // namespace LanguageServices
+} // namespace Tw

--- a/src/languageservices/LanguageServiceManager.h
+++ b/src/languageservices/LanguageServiceManager.h
@@ -12,10 +12,18 @@
 
 #include "languageservices/LanguageService.h"
 
+#include <QHash>
 #include <QObject>
+#include <QPointer>
+#include <QStringList>
+#include <QTimer>
+
+namespace Tw { namespace Document { class TeXDocument; } }
 
 namespace Tw {
 namespace LanguageServices {
+
+class LanguageServiceDocumentBinding;
 
 class LanguageServiceManager : public QObject
 {
@@ -25,29 +33,64 @@ public:
 	explicit LanguageServiceManager(QObject * parent = nullptr);
 	~LanguageServiceManager() override;
 
-	bool setService(LanguageService * service);
-	bool replaceService(LanguageService * service, bool startService = true);
+	bool setService(LanguageService * service, const QStringList & supportedLanguages = QStringList{});
+	bool replaceService(LanguageService * service, const QStringList & supportedLanguages = QStringList{},
+	                    bool startService = true);
 	LanguageService * service() const { return m_service; }
 	LanguageService::State state() const;
 	LanguageServiceCapabilities capabilities() const;
 
 	bool start();
 	void stop();
+	void registerDocument(Document::TeXDocument * document, const QString & sourceLanguage = QString{});
+	void unregisterDocument(Document::TeXDocument * document);
+	void updateDocumentIdentity(Document::TeXDocument * document);
+	void updateDocumentLanguageHint(Document::TeXDocument * document, const QString & sourceLanguage);
+	LanguageServiceDocumentBinding * bindingForDocument(Document::TeXDocument * document) const;
+	bool canRequestCompletion(Document::TeXDocument * document) const;
+	bool requestCompletion(Document::TeXDocument * document, const LanguagePosition & position);
+	void cancelCompletionRequest(Document::TeXDocument * document);
+	void beginCompletionEdit(Document::TeXDocument * document);
+	void endCompletionEdit(Document::TeXDocument * document);
+	bool canRequestDefinition(Document::TeXDocument * document) const;
+	bool requestDefinition(Document::TeXDocument * document, const LanguagePosition & position);
+	void cancelDefinitionRequest(Document::TeXDocument * document);
+
+	static bool isSourceEligible(const Document::TeXDocument * document);
+	static QString identifyLanguageId(const Document::TeXDocument * document, const QString & sourceLanguage = QString{});
 
 signals:
 	void serviceChanged(Tw::LanguageServices::LanguageService * service);
 	void stateChanged(Tw::LanguageServices::LanguageService::State state);
 	void capabilitiesChanged(const Tw::LanguageServices::LanguageServiceCapabilities & capabilities);
 	void failed(const QString & reason);
+	void completionAvailabilityChanged(Tw::Document::TeXDocument * document, bool available);
+	void completionReady(Tw::Document::TeXDocument * document,
+	                     const QList<Tw::LanguageServices::CompletionItem> & items);
+	void definitionAvailabilityChanged(Tw::Document::TeXDocument * document, bool available);
+	void definitionReady(Tw::Document::TeXDocument * document,
+	                     const QList<Tw::LanguageServices::LanguageLocation> & locations);
+
+private slots:
+	void refreshPendingDocuments();
 
 private:
-	void installService(LanguageService * service);
+	void installService(LanguageService * service, const QStringList & supportedLanguages);
 	void finishServiceReplacement();
+	void createBinding(Document::TeXDocument * document);
+	void scheduleDocumentRefresh(Document::TeXDocument * document);
+	void refreshBinding(Document::TeXDocument * document);
 
 	LanguageService * m_service{nullptr};
 	LanguageService * m_pendingService{nullptr};
+	QStringList m_pendingSupportedLanguages;
 	bool m_startPendingService{false};
 	bool m_replacingService{false};
+	QStringList m_supportedLanguages;
+	QHash<Document::TeXDocument *, QString> m_documents;
+	QHash<Document::TeXDocument *, LanguageServiceDocumentBinding *> m_bindings;
+	QTimer m_deferredRefreshTimer;
+	QList<QPointer<Document::TeXDocument>> m_pendingDocumentRefreshes;
 };
 
 } // namespace LanguageServices

--- a/src/languageservices/LanguageServiceManager.h
+++ b/src/languageservices/LanguageServiceManager.h
@@ -1,0 +1,56 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+#ifndef LANGUAGESERVICEMANAGER_H
+#define LANGUAGESERVICEMANAGER_H
+
+#include "languageservices/LanguageService.h"
+
+#include <QObject>
+
+namespace Tw {
+namespace LanguageServices {
+
+class LanguageServiceManager : public QObject
+{
+	Q_OBJECT
+
+public:
+	explicit LanguageServiceManager(QObject * parent = nullptr);
+	~LanguageServiceManager() override;
+
+	bool setService(LanguageService * service);
+	bool replaceService(LanguageService * service, bool startService = true);
+	LanguageService * service() const { return m_service; }
+	LanguageService::State state() const;
+	LanguageServiceCapabilities capabilities() const;
+
+	bool start();
+	void stop();
+
+signals:
+	void serviceChanged(Tw::LanguageServices::LanguageService * service);
+	void stateChanged(Tw::LanguageServices::LanguageService::State state);
+	void capabilitiesChanged(const Tw::LanguageServices::LanguageServiceCapabilities & capabilities);
+	void failed(const QString & reason);
+
+private:
+	void installService(LanguageService * service);
+	void finishServiceReplacement();
+
+	LanguageService * m_service{nullptr};
+	LanguageService * m_pendingService{nullptr};
+	bool m_startPendingService{false};
+	bool m_replacingService{false};
+};
+
+} // namespace LanguageServices
+} // namespace Tw
+
+#endif // LANGUAGESERVICEMANAGER_H

--- a/src/languageservices/LanguageServiceNavigation.cpp
+++ b/src/languageservices/LanguageServiceNavigation.cpp
@@ -1,0 +1,41 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+
+#include "languageservices/LanguageServiceNavigation.h"
+
+#include <QTextBlock>
+#include <QTextDocument>
+
+namespace Tw {
+namespace LanguageServices {
+
+bool cursorForLanguageRange(QTextDocument * document, const LanguageRange & range, QTextCursor & cursor)
+{
+	if (!document || range.start.line < 0 || range.start.character < 0
+	    || range.end.line < range.start.line || range.end.character < 0)
+		return false;
+	const QTextBlock startBlock = document->findBlockByNumber(range.start.line);
+	const QTextBlock endBlock = document->findBlockByNumber(range.end.line);
+	if (!startBlock.isValid() || !endBlock.isValid()
+	    || range.start.character > startBlock.text().size()
+	    || range.end.character > endBlock.text().size())
+		return false;
+	const int start = startBlock.position() + range.start.character;
+	const int end = endBlock.position() + range.end.character;
+	if (end < start)
+		return false;
+	cursor = QTextCursor(document);
+	cursor.setPosition(start);
+	cursor.setPosition(end, QTextCursor::KeepAnchor);
+	return true;
+}
+
+} // namespace LanguageServices
+} // namespace Tw

--- a/src/languageservices/LanguageServiceNavigation.h
+++ b/src/languageservices/LanguageServiceNavigation.h
@@ -1,0 +1,27 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+#ifndef LANGUAGESERVICENAVIGATION_H
+#define LANGUAGESERVICENAVIGATION_H
+
+#include "languageservices/LanguageServiceTypes.h"
+
+#include <QTextCursor>
+
+class QTextDocument;
+
+namespace Tw {
+namespace LanguageServices {
+
+bool cursorForLanguageRange(QTextDocument * document, const LanguageRange & range, QTextCursor & cursor);
+
+} // namespace LanguageServices
+} // namespace Tw
+
+#endif // LANGUAGESERVICENAVIGATION_H

--- a/src/languageservices/LanguageServiceTypes.h
+++ b/src/languageservices/LanguageServiceTypes.h
@@ -1,0 +1,63 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+#ifndef LANGUAGESERVICETYPES_H
+#define LANGUAGESERVICETYPES_H
+
+#include <QMetaType>
+
+namespace Tw {
+namespace LanguageServices {
+
+enum class TextSyncKind {
+	None,
+	Full,
+	Incremental
+};
+
+struct LanguageServiceCapabilities
+{
+	TextSyncKind textSync{TextSyncKind::None};
+	bool openClose{false};
+	bool completion{false};
+	bool signatureHelp{false};
+	bool hover{false};
+	bool definition{false};
+	bool references{false};
+	bool documentSymbols{false};
+	bool workspaceSymbols{false};
+	bool diagnostics{false};
+};
+
+inline bool operator==(const LanguageServiceCapabilities & lhs, const LanguageServiceCapabilities & rhs)
+{
+	return lhs.textSync == rhs.textSync
+	       && lhs.openClose == rhs.openClose
+	       && lhs.completion == rhs.completion
+	       && lhs.signatureHelp == rhs.signatureHelp
+	       && lhs.hover == rhs.hover
+	       && lhs.definition == rhs.definition
+	       && lhs.references == rhs.references
+	       && lhs.documentSymbols == rhs.documentSymbols
+	       && lhs.workspaceSymbols == rhs.workspaceSymbols
+	       && lhs.diagnostics == rhs.diagnostics;
+}
+
+inline bool operator!=(const LanguageServiceCapabilities & lhs, const LanguageServiceCapabilities & rhs)
+{
+	return !(lhs == rhs);
+}
+
+} // namespace LanguageServices
+} // namespace Tw
+
+Q_DECLARE_METATYPE(Tw::LanguageServices::TextSyncKind)
+Q_DECLARE_METATYPE(Tw::LanguageServices::LanguageServiceCapabilities)
+
+#endif // LANGUAGESERVICETYPES_H

--- a/src/languageservices/LanguageServiceTypes.h
+++ b/src/languageservices/LanguageServiceTypes.h
@@ -10,7 +10,10 @@
 #ifndef LANGUAGESERVICETYPES_H
 #define LANGUAGESERVICETYPES_H
 
+#include <QList>
 #include <QMetaType>
+#include <QString>
+#include <QUrl>
 
 namespace Tw {
 namespace LanguageServices {
@@ -33,6 +36,65 @@ struct LanguageServiceCapabilities
 	bool documentSymbols{false};
 	bool workspaceSymbols{false};
 	bool diagnostics{false};
+};
+
+struct LanguagePosition
+{
+	int line{0};
+	int character{0};
+};
+
+struct LanguageRange
+{
+	LanguagePosition start;
+	LanguagePosition end;
+};
+
+struct LanguageLocation
+{
+	QUrl document;
+	LanguageRange range;
+};
+
+struct CompletionItem
+{
+	QString label;
+	QString detail;
+	QString documentation;
+	QString insertText;
+	bool hasReplacementRange{false};
+	LanguageRange replacementRange;
+};
+
+struct LanguageCompletionRequest
+{
+	quint64 token{0};
+	QUrl document;
+	quint64 synchronizedVersion{0};
+	LanguagePosition position;
+};
+
+struct LanguageDefinitionRequest
+{
+	quint64 token{0};
+	QUrl document;
+	quint64 synchronizedVersion{0};
+	LanguagePosition position;
+};
+
+struct LanguageDocumentOpen
+{
+	QUrl url;
+	QString languageId;
+	quint64 version{1};
+	QString text;
+};
+
+struct LanguageDocumentChange
+{
+	bool hasRange{false};
+	LanguageRange range;
+	QString text;
 };
 
 inline bool operator==(const LanguageServiceCapabilities & lhs, const LanguageServiceCapabilities & rhs)
@@ -59,5 +121,9 @@ inline bool operator!=(const LanguageServiceCapabilities & lhs, const LanguageSe
 
 Q_DECLARE_METATYPE(Tw::LanguageServices::TextSyncKind)
 Q_DECLARE_METATYPE(Tw::LanguageServices::LanguageServiceCapabilities)
+Q_DECLARE_METATYPE(Tw::LanguageServices::LanguageLocation)
+Q_DECLARE_METATYPE(QList<Tw::LanguageServices::LanguageLocation>)
+Q_DECLARE_METATYPE(Tw::LanguageServices::CompletionItem)
+Q_DECLARE_METATYPE(QList<Tw::LanguageServices::CompletionItem>)
 
 #endif // LANGUAGESERVICETYPES_H

--- a/src/languageservices/lsp/JsonRpcTransport.cpp
+++ b/src/languageservices/lsp/JsonRpcTransport.cpp
@@ -1,0 +1,297 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+	For links to further information, or to contact the authors,
+	see <https://tug.org/texworks/>.
+*/
+
+#include "languageservices/lsp/JsonRpcTransport.h"
+
+#include <QJsonDocument>
+#include <QJsonParseError>
+#include <QtGlobal>
+
+#include <cmath>
+
+namespace Tw {
+namespace LanguageServices {
+namespace Lsp {
+
+JsonRpcTransport::JsonRpcTransport(QObject * parent)
+	: QObject(parent)
+{
+}
+
+QByteArray JsonRpcTransport::frame(const QJsonObject & message)
+{
+	const QByteArray body = QJsonDocument(message).toJson(QJsonDocument::Compact);
+	return QByteArrayLiteral("Content-Length: ") + QByteArray::number(body.size()) + QByteArrayLiteral("\r\n\r\n") + body;
+}
+
+bool JsonRpcTransport::emitMessage(const QJsonObject & message)
+{
+	const QByteArray body = QJsonDocument(message).toJson(QJsonDocument::Compact);
+	if (body.size() > MaximumMessageSize) {
+		fail(tr("JSON-RPC message exceeds the maximum size"));
+		return false;
+	}
+	emit outgoingFrame(QByteArrayLiteral("Content-Length: ") + QByteArray::number(body.size()) + QByteArrayLiteral("\r\n\r\n") + body);
+	return !m_failed;
+}
+
+qint64 JsonRpcTransport::sendRequest(const QString & method, const QJsonValue & params)
+{
+	if (m_failed || method.isEmpty() || m_nextRequestId > MaximumRequestId)
+		return -1;
+
+	const qint64 id = m_nextRequestId;
+	QJsonObject message;
+	message.insert(QStringLiteral("jsonrpc"), QStringLiteral("2.0"));
+	message.insert(QStringLiteral("id"), static_cast<double>(id));
+	message.insert(QStringLiteral("method"), method);
+	if (!params.isUndefined())
+		message.insert(QStringLiteral("params"), params);
+	const QByteArray body = QJsonDocument(message).toJson(QJsonDocument::Compact);
+	if (body.size() > MaximumMessageSize) {
+		fail(tr("JSON-RPC message exceeds the maximum size"));
+		return -1;
+	}
+	++m_nextRequestId;
+	m_pendingRequestIds.insert(id);
+	emit outgoingFrame(QByteArrayLiteral("Content-Length: ") + QByteArray::number(body.size()) + QByteArrayLiteral("\r\n\r\n") + body);
+	return m_failed ? -1 : id;
+}
+
+bool JsonRpcTransport::sendNotification(const QString & method, const QJsonValue & params)
+{
+	if (m_failed || method.isEmpty())
+		return false;
+
+	QJsonObject message;
+	message.insert(QStringLiteral("jsonrpc"), QStringLiteral("2.0"));
+	message.insert(QStringLiteral("method"), method);
+	if (!params.isUndefined())
+		message.insert(QStringLiteral("params"), params);
+	return emitMessage(message);
+}
+
+bool JsonRpcTransport::sendErrorResponse(const QJsonValue & id, int code, const QString & message)
+{
+	if (m_failed || message.isEmpty())
+		return false;
+
+	QJsonObject error;
+	error.insert(QStringLiteral("code"), code);
+	error.insert(QStringLiteral("message"), message);
+	QJsonObject response;
+	response.insert(QStringLiteral("jsonrpc"), QStringLiteral("2.0"));
+	response.insert(QStringLiteral("id"), id);
+	response.insert(QStringLiteral("error"), error);
+	return emitMessage(response);
+}
+
+void JsonRpcTransport::receiveData(const QByteArray & data)
+{
+	if (m_failed || data.isEmpty())
+		return;
+
+	decltype(data.size()) offset = 0;
+	while (!m_failed && offset < data.size()) {
+		const auto available = static_cast<decltype(data.size())>(MaximumReceiveBufferSize) - m_receiveBuffer.size();
+		if (available <= 0) {
+			fail(tr("JSON-RPC receive buffer exceeds the maximum size"));
+			return;
+		}
+		const auto chunkSize = qMin(available, data.size() - offset);
+		m_receiveBuffer.append(data.constData() + offset, chunkSize);
+		offset += chunkSize;
+		parseAvailableMessages();
+	}
+}
+
+void JsonRpcTransport::parseAvailableMessages()
+{
+	while (!m_failed) {
+		if (m_expectedBodySize < 0) {
+			const auto headerEnd = m_receiveBuffer.indexOf("\r\n\r\n");
+			if (headerEnd < 0) {
+				if (m_receiveBuffer.size() > MaximumHeaderSize)
+					fail(tr("JSON-RPC header exceeds the maximum size"));
+				return;
+			}
+			if (headerEnd > MaximumHeaderSize) {
+				fail(tr("JSON-RPC header exceeds the maximum size"));
+				return;
+			}
+			if (!parseHeader(headerEnd, m_expectedBodySize))
+				return;
+			m_receiveBuffer.remove(0, headerEnd + 4);
+		}
+
+		if (m_receiveBuffer.size() < m_expectedBodySize)
+			return;
+
+		const QByteArray body = m_receiveBuffer.left(m_expectedBodySize);
+		m_receiveBuffer.remove(0, m_expectedBodySize);
+		m_expectedBodySize = -1;
+		processMessage(body);
+	}
+}
+
+bool JsonRpcTransport::parseHeader(decltype(QByteArray().size()) headerEnd, int & contentLength)
+{
+	contentLength = -1;
+	const QList<QByteArray> lines = m_receiveBuffer.left(headerEnd).split('\n');
+	for (QByteArray line : lines) {
+		if (line.endsWith('\r'))
+			line.chop(1);
+		const auto colon = line.indexOf(':');
+		if (colon <= 0) {
+			fail(tr("Malformed JSON-RPC header"));
+			return false;
+		}
+		const QByteArray name = line.left(colon).trimmed();
+		const QByteArray value = line.mid(colon + 1).trimmed();
+		if (name.toLower() != QByteArrayLiteral("content-length"))
+			continue;
+		if (contentLength >= 0) {
+			fail(tr("Duplicate Content-Length header"));
+			return false;
+		}
+		if (value.isEmpty()) {
+			fail(tr("Invalid Content-Length header"));
+			return false;
+		}
+		for (char character : value) {
+			if (character < '0' || character > '9') {
+				fail(tr("Invalid Content-Length header"));
+				return false;
+			}
+		}
+		bool ok = false;
+		const qulonglong parsed = value.toULongLong(&ok, 10);
+		if (!ok || parsed > static_cast<qulonglong>(MaximumMessageSize)) {
+			fail(parsed > static_cast<qulonglong>(MaximumMessageSize)
+			         ? tr("JSON-RPC message exceeds the maximum size")
+			         : tr("Invalid Content-Length header"));
+			return false;
+		}
+		contentLength = static_cast<int>(parsed);
+	}
+
+	if (contentLength < 0) {
+		fail(tr("Missing Content-Length header"));
+		return false;
+	}
+	return true;
+}
+
+void JsonRpcTransport::processMessage(const QByteArray & body)
+{
+	QJsonParseError parseError;
+	const QJsonDocument document = QJsonDocument::fromJson(body, &parseError);
+	if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
+		fail(tr("Malformed JSON-RPC JSON body: %1").arg(parseError.errorString()));
+		return;
+	}
+
+	const QJsonObject message = document.object();
+	if (message.value(QStringLiteral("jsonrpc")) != QJsonValue(QStringLiteral("2.0"))) {
+		fail(tr("Invalid or missing JSON-RPC version marker"));
+		return;
+	}
+
+	const QJsonValue methodValue = message.value(QStringLiteral("method"));
+	const bool hasMethod = methodValue.isString() && !methodValue.toString().isEmpty();
+	const bool hasId = message.contains(QStringLiteral("id"));
+	const bool hasResult = message.contains(QStringLiteral("result"));
+	const bool hasError = message.contains(QStringLiteral("error"));
+
+	if (hasMethod && !hasResult && !hasError) {
+		const QJsonValue params = message.value(QStringLiteral("params"));
+		if (hasId)
+			emit requestReceived(message.value(QStringLiteral("id")), methodValue.toString(), params);
+		else
+			emit notificationReceived(methodValue.toString(), params);
+		return;
+	}
+
+	if (!hasMethod && hasId && (hasResult != hasError)) {
+		if (hasError && !message.value(QStringLiteral("error")).isObject()) {
+			fail(tr("JSON-RPC error response has a non-object error"));
+			return;
+		}
+		qint64 id = -1;
+		if (!correlatedRequestId(message.value(QStringLiteral("id")), id) || !m_pendingRequestIds.remove(id)) {
+			emit unknownResponseReceived(message.value(QStringLiteral("id")));
+			return;
+		}
+		if (hasResult) {
+			emit responseReceived(id, message.value(QStringLiteral("result")));
+			return;
+		}
+		emit errorResponseReceived(id, message.value(QStringLiteral("error")).toObject());
+		return;
+	}
+
+	fail(tr("Invalid JSON-RPC message shape"));
+}
+
+bool JsonRpcTransport::correlatedRequestId(const QJsonValue & value, qint64 & id) const
+{
+	if (!value.isDouble())
+		return false;
+	const double numericId = value.toDouble();
+	if (!std::isfinite(numericId) || std::floor(numericId) != numericId || numericId < 0
+	    || numericId > static_cast<double>(MaximumRequestId))
+		return false;
+	id = static_cast<qint64>(numericId);
+	return true;
+}
+
+void JsonRpcTransport::fail(const QString & reason)
+{
+	if (m_failed)
+		return;
+	m_failed = true;
+	m_receiveBuffer.clear();
+	m_expectedBodySize = -1;
+	invalidatePendingRequests(reason);
+	emit protocolError(reason);
+}
+
+void JsonRpcTransport::close(const QString & reason)
+{
+	if (m_failed)
+		return;
+	m_failed = true;
+	m_receiveBuffer.clear();
+	m_expectedBodySize = -1;
+	invalidatePendingRequests(reason);
+}
+
+void JsonRpcTransport::invalidatePendingRequests(const QString & reason)
+{
+	const QSet<qint64> pendingIds = m_pendingRequestIds;
+	m_pendingRequestIds.clear();
+	for (qint64 id : pendingIds)
+		emit pendingRequestFailed(id, reason);
+}
+
+} // namespace Lsp
+} // namespace LanguageServices
+} // namespace Tw

--- a/src/languageservices/lsp/JsonRpcTransport.h
+++ b/src/languageservices/lsp/JsonRpcTransport.h
@@ -1,0 +1,87 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+	For links to further information, or to contact the authors,
+	see <https://tug.org/texworks/>.
+*/
+#ifndef JSONRPCTRANSPORT_H
+#define JSONRPCTRANSPORT_H
+
+#include <QByteArray>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QObject>
+#include <QSet>
+
+namespace Tw {
+namespace LanguageServices {
+namespace Lsp {
+
+class JsonRpcTransport : public QObject
+{
+	Q_OBJECT
+
+public:
+	static const int MaximumHeaderSize = 16 * 1024;
+	static const int MaximumMessageSize = 8 * 1024 * 1024;
+	static const int MaximumReceiveBufferSize = MaximumHeaderSize + MaximumMessageSize + 4;
+	static const qint64 MaximumRequestId = 9007199254740991LL;
+
+	explicit JsonRpcTransport(QObject * parent = nullptr);
+
+	bool isFailed() const { return m_failed; }
+	int pendingRequestCount() const { return static_cast<int>(m_pendingRequestIds.size()); }
+
+	qint64 sendRequest(const QString & method, const QJsonValue & params = QJsonValue(QJsonValue::Undefined));
+	bool sendNotification(const QString & method, const QJsonValue & params = QJsonValue(QJsonValue::Undefined));
+	bool sendErrorResponse(const QJsonValue & id, int code, const QString & message);
+	void receiveData(const QByteArray & data);
+	void fail(const QString & reason);
+	void close(const QString & reason);
+
+	static QByteArray frame(const QJsonObject & message);
+
+signals:
+	void outgoingFrame(const QByteArray & frame);
+	void responseReceived(qint64 id, const QJsonValue & result);
+	void errorResponseReceived(qint64 id, const QJsonObject & error);
+	void unknownResponseReceived(const QJsonValue & id);
+	void notificationReceived(const QString & method, const QJsonValue & params);
+	void requestReceived(const QJsonValue & id, const QString & method, const QJsonValue & params);
+	void pendingRequestFailed(qint64 id, const QString & reason);
+	void protocolError(const QString & reason);
+
+private:
+	bool emitMessage(const QJsonObject & message);
+	void invalidatePendingRequests(const QString & reason);
+	void parseAvailableMessages();
+	bool parseHeader(decltype(QByteArray().size()) headerEnd, int & contentLength);
+	void processMessage(const QByteArray & body);
+	bool correlatedRequestId(const QJsonValue & value, qint64 & id) const;
+
+	QByteArray m_receiveBuffer;
+	QSet<qint64> m_pendingRequestIds;
+	qint64 m_nextRequestId{1};
+	int m_expectedBodySize{-1};
+	bool m_failed{false};
+};
+
+} // namespace Lsp
+} // namespace LanguageServices
+} // namespace Tw
+
+#endif // JSONRPCTRANSPORT_H

--- a/src/languageservices/lsp/LanguageServerProcess.cpp
+++ b/src/languageservices/lsp/LanguageServerProcess.cpp
@@ -1,0 +1,176 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+	For links to further information, or to contact the authors,
+	see <https://tug.org/texworks/>.
+*/
+
+#include "languageservices/lsp/LanguageServerProcess.h"
+
+namespace Tw {
+namespace LanguageServices {
+namespace Lsp {
+
+LanguageServerProcess::LanguageServerProcess(QObject * parent)
+	: QObject(parent)
+{
+	m_process.setProcessChannelMode(QProcess::SeparateChannels);
+	m_gracefulTimer.setSingleShot(true);
+	m_terminateTimer.setSingleShot(true);
+
+	connect(&m_process, &QProcess::started, this, [this]() {
+		if (!m_stopRequested)
+			setState(Running);
+	});
+	connect(&m_process, &QProcess::readyReadStandardOutput, this, [this]() {
+		m_transport.receiveData(m_process.readAllStandardOutput());
+	});
+	connect(&m_process, &QProcess::readyReadStandardError, this, [this]() {
+		emit standardErrorReceived(m_process.readAllStandardError());
+	});
+#if QT_VERSION < QT_VERSION_CHECK(5, 6, 0)
+	connect(&m_process, static_cast<void (QProcess::*)(QProcess::ProcessError)>(&QProcess::error), this, &LanguageServerProcess::handleProcessError);
+#else
+	connect(&m_process, &QProcess::errorOccurred, this, &LanguageServerProcess::handleProcessError);
+#endif
+	connect(&m_process, static_cast<void (QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished),
+	        this, &LanguageServerProcess::handleFinished);
+	connect(&m_transport, &JsonRpcTransport::outgoingFrame, this, &LanguageServerProcess::writeFrame);
+	connect(&m_transport, &JsonRpcTransport::protocolError, this, &LanguageServerProcess::handleProtocolError);
+	connect(&m_gracefulTimer, &QTimer::timeout, this, &LanguageServerProcess::forceTerminate);
+	connect(&m_terminateTimer, &QTimer::timeout, this, &LanguageServerProcess::forceKill);
+}
+
+LanguageServerProcess::~LanguageServerProcess()
+{
+	m_gracefulTimer.stop();
+	m_terminateTimer.stop();
+	if (m_process.state() != QProcess::NotRunning) {
+		disconnect(&m_process, nullptr, this, nullptr);
+		disconnect(&m_transport, nullptr, this, nullptr);
+		m_process.kill();
+		m_process.waitForFinished(1000);
+	}
+}
+
+bool LanguageServerProcess::start(const QString & program, const QStringList & arguments,
+	                              const QProcessEnvironment & environment, const QString & workingDirectory)
+{
+	if (m_state != NotRunning || m_transport.isFailed() || program.isEmpty())
+		return false;
+
+	m_stopRequested = false;
+	m_process.setProcessEnvironment(environment);
+	m_process.setWorkingDirectory(workingDirectory);
+	m_process.setProcessChannelMode(QProcess::SeparateChannels);
+	setState(Starting);
+	m_process.start(program, arguments);
+	return true;
+}
+
+void LanguageServerProcess::stop(int gracefulTimeoutMs, int terminateTimeoutMs)
+{
+	if (m_process.state() == QProcess::NotRunning) {
+		if (m_state != Failed)
+			setState(NotRunning);
+		return;
+	}
+
+	m_stopRequested = true;
+	setState(Stopping);
+	m_process.closeWriteChannel();
+	m_gracefulTimer.start(qMax(0, gracefulTimeoutMs));
+	m_terminateTimer.setInterval(qMax(0, terminateTimeoutMs));
+}
+
+void LanguageServerProcess::writeFrame(const QByteArray & frame)
+{
+	if (m_state != Running || m_process.write(frame) < 0) {
+		const QString description = tr("Could not write to the language server process");
+		emit writeFailed(description);
+		m_transport.fail(description);
+	}
+}
+
+void LanguageServerProcess::handleProcessError(QProcess::ProcessError error)
+{
+	const QString description = m_process.errorString();
+	emit processError(error, description);
+	if (m_stopRequested && error == QProcess::Crashed)
+		return;
+	if (error == QProcess::FailedToStart || error == QProcess::Crashed || error == QProcess::WriteError || error == QProcess::ReadError) {
+		m_gracefulTimer.stop();
+		m_terminateTimer.stop();
+		setState(Failed);
+		m_transport.fail(description);
+	}
+}
+
+void LanguageServerProcess::handleFinished(int exitCode, QProcess::ExitStatus exitStatus)
+{
+	const bool unexpected = !m_stopRequested;
+	m_gracefulTimer.stop();
+	m_terminateTimer.stop();
+	const QByteArray remainingOutput = m_process.readAllStandardOutput();
+	if (!remainingOutput.isEmpty())
+		m_transport.receiveData(remainingOutput);
+	const QByteArray remainingError = m_process.readAllStandardError();
+	if (!remainingError.isEmpty())
+		emit standardErrorReceived(remainingError);
+	emit processFinished(exitCode, exitStatus, unexpected);
+	if (unexpected) {
+		setState(Failed);
+		m_transport.fail(tr("Language server process exited unexpectedly"));
+	}
+	else {
+		m_transport.close(tr("Language server process stopped"));
+		setState(NotRunning);
+	}
+}
+
+void LanguageServerProcess::handleProtocolError(const QString &)
+{
+	if (m_process.state() != QProcess::NotRunning)
+		m_process.kill();
+	setState(Failed);
+}
+
+void LanguageServerProcess::setState(State state)
+{
+	if (m_state == state)
+		return;
+	m_state = state;
+	emit stateChanged(m_state);
+}
+
+void LanguageServerProcess::forceTerminate()
+{
+	if (m_process.state() == QProcess::NotRunning)
+		return;
+	m_process.terminate();
+	m_terminateTimer.start();
+}
+
+void LanguageServerProcess::forceKill()
+{
+	if (m_process.state() != QProcess::NotRunning)
+		m_process.kill();
+}
+
+} // namespace Lsp
+} // namespace LanguageServices
+} // namespace Tw

--- a/src/languageservices/lsp/LanguageServerProcess.h
+++ b/src/languageservices/lsp/LanguageServerProcess.h
@@ -1,0 +1,92 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+	For links to further information, or to contact the authors,
+	see <https://tug.org/texworks/>.
+*/
+#ifndef LANGUAGESERVERPROCESS_H
+#define LANGUAGESERVERPROCESS_H
+
+#include "languageservices/lsp/JsonRpcTransport.h"
+
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QTimer>
+
+namespace Tw {
+namespace LanguageServices {
+namespace Lsp {
+
+class LanguageServerProcess : public QObject
+{
+	Q_OBJECT
+
+public:
+	enum State {
+		NotRunning,
+		Starting,
+		Running,
+		Stopping,
+		Failed
+	};
+	Q_ENUMS(State)
+
+	explicit LanguageServerProcess(QObject * parent = nullptr);
+	~LanguageServerProcess() override;
+
+	State state() const { return m_state; }
+	JsonRpcTransport * transport() { return &m_transport; }
+	const JsonRpcTransport * transport() const { return &m_transport; }
+
+	bool start(const QString & program, const QStringList & arguments = {},
+	           const QProcessEnvironment & environment = QProcessEnvironment::systemEnvironment(),
+	           const QString & workingDirectory = {});
+	void stop(int gracefulTimeoutMs = 1000, int terminateTimeoutMs = 1000);
+
+signals:
+	void stateChanged(Tw::LanguageServices::Lsp::LanguageServerProcess::State state);
+	void standardErrorReceived(const QByteArray & data);
+	void processError(QProcess::ProcessError error, const QString & description);
+	void processFinished(int exitCode, QProcess::ExitStatus exitStatus, bool unexpected);
+	void writeFailed(const QString & description);
+
+private slots:
+	void writeFrame(const QByteArray & frame);
+	void handleProcessError(QProcess::ProcessError error);
+	void handleFinished(int exitCode, QProcess::ExitStatus exitStatus);
+	void handleProtocolError(const QString & reason);
+
+private:
+	void setState(State state);
+	void forceTerminate();
+	void forceKill();
+
+	QProcess m_process;
+	JsonRpcTransport m_transport;
+	QTimer m_gracefulTimer;
+	QTimer m_terminateTimer;
+	State m_state{NotRunning};
+	bool m_stopRequested{false};
+};
+
+} // namespace Lsp
+} // namespace LanguageServices
+} // namespace Tw
+
+Q_DECLARE_METATYPE(Tw::LanguageServices::Lsp::LanguageServerProcess::State)
+
+#endif // LANGUAGESERVERPROCESS_H

--- a/src/languageservices/lsp/LanguageServerProcess.h
+++ b/src/languageservices/lsp/LanguageServerProcess.h
@@ -49,6 +49,7 @@ public:
 	~LanguageServerProcess() override;
 
 	State state() const { return m_state; }
+	bool isRunning() const { return m_process.state() != QProcess::NotRunning; }
 	JsonRpcTransport * transport() { return &m_transport; }
 	const JsonRpcTransport * transport() const { return &m_transport; }
 

--- a/src/languageservices/lsp/LspLanguageService.cpp
+++ b/src/languageservices/lsp/LspLanguageService.cpp
@@ -14,7 +14,9 @@
 #include <QJsonArray>
 #include <QPair>
 
+#include <cmath>
 #include <initializer_list>
+#include <limits>
 
 namespace Tw {
 namespace LanguageServices {
@@ -48,6 +50,41 @@ QString errorResponseDescription(const QJsonObject & error)
 	const QString message = error.value(QStringLiteral("message")).toString();
 	return message.isEmpty() ? LspLanguageService::tr("Language server rejected initialization")
 	                         : LspLanguageService::tr("Language server rejected initialization: %1").arg(message);
+}
+
+bool parsePosition(const QJsonValue & value, LanguagePosition & position)
+{
+	if (!value.isObject())
+		return false;
+	const QJsonObject object = value.toObject();
+	const QJsonValue line = object.value(QStringLiteral("line"));
+	const QJsonValue character = object.value(QStringLiteral("character"));
+	if (!line.isDouble() || !character.isDouble())
+		return false;
+	const double lineNumber = line.toDouble();
+	const double characterNumber = character.toDouble();
+	if (!std::isfinite(lineNumber) || !std::isfinite(characterNumber)
+	    || lineNumber < 0 || characterNumber < 0
+	    || lineNumber > std::numeric_limits<int>::max()
+	    || characterNumber > std::numeric_limits<int>::max()
+	    || lineNumber != static_cast<int>(lineNumber)
+	    || characterNumber != static_cast<int>(characterNumber))
+		return false;
+	position.line = static_cast<int>(lineNumber);
+	position.character = static_cast<int>(characterNumber);
+	return true;
+}
+
+bool parseRange(const QJsonValue & value, LanguageRange & range)
+{
+	if (!value.isObject())
+		return false;
+	const QJsonObject object = value.toObject();
+	if (!parsePosition(object.value(QStringLiteral("start")), range.start)
+	    || !parsePosition(object.value(QStringLiteral("end")), range.end))
+		return false;
+	return range.end.line > range.start.line
+	       || (range.end.line == range.start.line && range.end.character >= range.start.character);
 }
 
 } // namespace
@@ -138,6 +175,28 @@ void LspLanguageService::beginInitialize()
 
 void LspLanguageService::handleResponse(qint64 id, const QJsonValue & result)
 {
+	const auto completion = m_completionRequests.find(id);
+	if (completion != m_completionRequests.end()) {
+		const quint64 token = completion.value();
+		m_completionRequests.erase(completion);
+		QList<CompletionItem> items;
+		if (mapCompletionResult(result, items))
+			emit completionFinished(token, items);
+		else
+			emit completionFailed(token, tr("Language server returned an invalid completion result"));
+		return;
+	}
+	const auto definition = m_definitionRequests.find(id);
+	if (definition != m_definitionRequests.end()) {
+		const quint64 token = definition.value();
+		m_definitionRequests.erase(definition);
+		QList<LanguageLocation> locations;
+		if (mapDefinitionResult(result, locations))
+			emit definitionFinished(token, locations);
+		else
+			emit definitionFailed(token, tr("Language server returned an invalid definition result"));
+		return;
+	}
 	if (id == m_initializeRequestId) {
 		m_initializeRequestId = -1;
 		m_initializeTimer.stop();
@@ -183,6 +242,20 @@ void LspLanguageService::handleResponse(qint64 id, const QJsonValue & result)
 
 void LspLanguageService::handleErrorResponse(qint64 id, const QJsonObject & error)
 {
+	const auto completion = m_completionRequests.find(id);
+	if (completion != m_completionRequests.end()) {
+		const quint64 token = completion.value();
+		m_completionRequests.erase(completion);
+		emit completionFailed(token, error.value(QStringLiteral("message")).toString());
+		return;
+	}
+	const auto definition = m_definitionRequests.find(id);
+	if (definition != m_definitionRequests.end()) {
+		const quint64 token = definition.value();
+		m_definitionRequests.erase(definition);
+		emit definitionFailed(token, error.value(QStringLiteral("message")).toString());
+		return;
+	}
 	if (id == m_initializeRequestId) {
 		m_initializeRequestId = -1;
 		m_initializeTimer.stop();
@@ -198,6 +271,20 @@ void LspLanguageService::handleErrorResponse(qint64 id, const QJsonObject & erro
 
 void LspLanguageService::handlePendingFailure(qint64 id, const QString & reason)
 {
+	const auto completion = m_completionRequests.find(id);
+	if (completion != m_completionRequests.end()) {
+		const quint64 token = completion.value();
+		m_completionRequests.erase(completion);
+		emit completionFailed(token, reason);
+		return;
+	}
+	const auto definition = m_definitionRequests.find(id);
+	if (definition != m_definitionRequests.end()) {
+		const quint64 token = definition.value();
+		m_definitionRequests.erase(definition);
+		emit definitionFailed(token, reason);
+		return;
+	}
 	if (id == m_initializeRequestId && state() == Initializing) {
 		m_initializeRequestId = -1;
 		m_initializeTimer.stop();
@@ -274,6 +361,8 @@ void LspLanguageService::initializationFailed(const QString & reason)
 	m_initializeTimer.stop();
 	m_shutdownTimer.stop();
 	becomeFailed(reason);
+	failCompletionRequests(reason);
+	failDefinitionRequests(reason);
 	beginProcessStop();
 }
 
@@ -300,6 +389,212 @@ void LspLanguageService::stop()
 	m_shutdownTimer.start(m_shutdownTimeoutMs);
 }
 
+bool LspLanguageService::openDocument(const LanguageDocumentOpen & document)
+{
+	if (!isReady())
+		return false;
+	const QJsonObject item = jsonObject({
+		{QStringLiteral("uri"), document.url.toString(QUrl::FullyEncoded)},
+		{QStringLiteral("languageId"), document.languageId},
+		{QStringLiteral("version"), static_cast<double>(document.version)},
+		{QStringLiteral("text"), document.text}
+	});
+	return m_process.transport()->sendNotification(QStringLiteral("textDocument/didOpen"),
+	                                               jsonObject({{QStringLiteral("textDocument"), item}}));
+}
+
+bool LspLanguageService::changeDocument(const QUrl & url, quint64 version, const LanguageDocumentChange & change)
+{
+	if (!isReady())
+		return false;
+	QJsonObject contentChange = jsonObject({{QStringLiteral("text"), change.text}});
+	if (change.hasRange) {
+		const auto position = [](const LanguagePosition & value) {
+			return jsonObject({{QStringLiteral("line"), value.line},
+			                   {QStringLiteral("character"), value.character}});
+		};
+		contentChange.insert(QStringLiteral("range"),
+		                     jsonObject({{QStringLiteral("start"), position(change.range.start)},
+		                                 {QStringLiteral("end"), position(change.range.end)}}));
+	}
+	const QJsonObject identifier = jsonObject({
+		{QStringLiteral("uri"), url.toString(QUrl::FullyEncoded)},
+		{QStringLiteral("version"), static_cast<double>(version)}
+	});
+	return m_process.transport()->sendNotification(QStringLiteral("textDocument/didChange"),
+	                                               jsonObject({{QStringLiteral("textDocument"), identifier},
+	                                                           {QStringLiteral("contentChanges"), jsonArray({contentChange})}}));
+}
+
+bool LspLanguageService::closeDocument(const QUrl & url)
+{
+	if (!isReady())
+		return false;
+	return m_process.transport()->sendNotification(QStringLiteral("textDocument/didClose"),
+	                                               jsonObject({{QStringLiteral("textDocument"),
+	                                                            jsonObject({{QStringLiteral("uri"), url.toString(QUrl::FullyEncoded)}})}}));
+}
+
+bool LspLanguageService::requestCompletion(const LanguageCompletionRequest & request)
+{
+	if (!isReady() || !capabilities().completion || request.token == 0
+	    || request.document.isEmpty() || request.position.line < 0 || request.position.character < 0)
+		return false;
+	const QJsonObject position = jsonObject({{QStringLiteral("line"), request.position.line},
+	                                         {QStringLiteral("character"), request.position.character}});
+	const QJsonObject identifier = jsonObject({{QStringLiteral("uri"), request.document.toString(QUrl::FullyEncoded)}});
+	const QJsonObject parameters = jsonObject({{QStringLiteral("textDocument"), identifier},
+	                                           {QStringLiteral("position"), position}});
+	const qint64 id = m_process.transport()->sendRequest(QStringLiteral("textDocument/completion"), parameters);
+	if (id < 0)
+		return false;
+	m_completionRequests.insert(id, request.token);
+	return true;
+}
+
+bool LspLanguageService::mapCompletionResult(const QJsonValue & result, QList<CompletionItem> & items) const
+{
+	if (result.isNull())
+		return true;
+	QJsonArray values;
+	if (result.isArray()) {
+		values = result.toArray();
+	}
+	else if (result.isObject()) {
+		const QJsonValue listItems = result.toObject().value(QStringLiteral("items"));
+		if (!listItems.isArray())
+			return false;
+		values = listItems.toArray();
+	}
+	else {
+		return false;
+	}
+
+	for (const QJsonValue & value : values) {
+		if (!value.isObject())
+			continue;
+		const QJsonObject object = value.toObject();
+		const QJsonValue label = object.value(QStringLiteral("label"));
+		if (!label.isString() || label.toString().isEmpty()
+		    || object.contains(QStringLiteral("additionalTextEdits"))
+		    || object.contains(QStringLiteral("command")))
+			continue;
+		const QJsonValue format = object.value(QStringLiteral("insertTextFormat"));
+		if (!format.isUndefined()
+		    && (!format.isDouble() || format.toDouble() != static_cast<int>(format.toDouble())
+		        || format.toInt() < 1 || format.toInt() > 2))
+			continue;
+		// Snippet placeholders are intentionally unsupported in this first cycle.
+		if (format.toInt(1) == 2)
+			continue;
+
+		CompletionItem item;
+		item.label = label.toString();
+		item.detail = object.value(QStringLiteral("detail")).toString();
+		const QJsonValue documentation = object.value(QStringLiteral("documentation"));
+		if (documentation.isString())
+			item.documentation = documentation.toString();
+		else if (documentation.isObject())
+			item.documentation = documentation.toObject().value(QStringLiteral("value")).toString();
+
+		const QJsonValue textEdit = object.value(QStringLiteral("textEdit"));
+		if (!textEdit.isUndefined()) {
+			if (!textEdit.isObject())
+				continue;
+			const QJsonObject edit = textEdit.toObject();
+			if (!edit.value(QStringLiteral("newText")).isString()
+			    || !parseRange(edit.value(QStringLiteral("range")), item.replacementRange))
+				continue;
+			item.insertText = edit.value(QStringLiteral("newText")).toString();
+			item.hasReplacementRange = true;
+		}
+		else if (object.value(QStringLiteral("insertText")).isString()) {
+			item.insertText = object.value(QStringLiteral("insertText")).toString();
+		}
+		else {
+			item.insertText = item.label;
+		}
+		items.append(item);
+	}
+	return true;
+}
+
+bool LspLanguageService::requestDefinition(const LanguageDefinitionRequest & request)
+{
+	if (!isReady() || !capabilities().definition || request.token == 0
+	    || request.document.isEmpty() || request.position.line < 0 || request.position.character < 0)
+		return false;
+	const QJsonObject position = jsonObject({{QStringLiteral("line"), request.position.line},
+	                                         {QStringLiteral("character"), request.position.character}});
+	const QJsonObject identifier = jsonObject({{QStringLiteral("uri"), request.document.toString(QUrl::FullyEncoded)}});
+	const QJsonObject parameters = jsonObject({{QStringLiteral("textDocument"), identifier},
+	                                           {QStringLiteral("position"), position}});
+	const qint64 id = m_process.transport()->sendRequest(QStringLiteral("textDocument/definition"), parameters);
+	if (id < 0)
+		return false;
+	m_definitionRequests.insert(id, request.token);
+	return true;
+}
+
+bool LspLanguageService::mapDefinitionResult(const QJsonValue & result, QList<LanguageLocation> & locations) const
+{
+	if (result.isNull())
+		return true;
+	QJsonArray values;
+	const bool singleLocation = result.isObject();
+	if (result.isArray())
+		values = result.toArray();
+	else if (result.isObject())
+		values.append(result);
+	else
+		return false;
+
+	int arrayKind = -1;
+	for (const QJsonValue & value : values) {
+		if (!value.isObject())
+			return false;
+		const QJsonObject object = value.toObject();
+		const bool locationLink = object.contains(QStringLiteral("targetUri"));
+		if (singleLocation && locationLink)
+			return false;
+		if (!singleLocation) {
+			const int currentKind = locationLink ? 1 : 0;
+			if (arrayKind >= 0 && currentKind != arrayKind)
+				return false;
+			arrayKind = currentKind;
+		}
+		const QJsonValue uriValue = object.value(locationLink ? QStringLiteral("targetUri") : QStringLiteral("uri"));
+		const QJsonValue rangeValue = object.value(locationLink ? QStringLiteral("targetSelectionRange") : QStringLiteral("range"));
+		if (!uriValue.isString())
+			return false;
+		LanguageLocation location;
+		location.document = QUrl(uriValue.toString(), QUrl::StrictMode);
+		LanguageRange targetRange;
+		if (!location.document.isValid() || location.document.isEmpty() || location.document.isRelative()
+		    || !parseRange(rangeValue, location.range)
+		    || (locationLink && !parseRange(object.value(QStringLiteral("targetRange")), targetRange)))
+			return false;
+		locations.append(location);
+	}
+	return true;
+}
+
+void LspLanguageService::failDefinitionRequests(const QString & reason)
+{
+	const QHash<qint64, quint64> requests = m_definitionRequests;
+	m_definitionRequests.clear();
+	for (quint64 token : requests)
+		emit definitionFailed(token, reason);
+}
+
+void LspLanguageService::failCompletionRequests(const QString & reason)
+{
+	const QHash<qint64, quint64> requests = m_completionRequests;
+	m_completionRequests.clear();
+	for (quint64 token : requests)
+		emit completionFailed(token, reason);
+}
+
 void LspLanguageService::sendExitAndStop()
 {
 	if (m_teardownStarted)
@@ -314,6 +609,8 @@ void LspLanguageService::beginProcessStop()
 	if (m_teardownStarted)
 		return;
 	m_teardownStarted = true;
+	failCompletionRequests(tr("Language server stopped"));
+	failDefinitionRequests(tr("Language server stopped"));
 	m_process.stop(m_shutdownTimeoutMs, m_terminateTimeoutMs);
 	if (m_process.state() == LanguageServerProcess::NotRunning && state() == Stopping)
 		becomeStopped();

--- a/src/languageservices/lsp/LspLanguageService.cpp
+++ b/src/languageservices/lsp/LspLanguageService.cpp
@@ -1,0 +1,324 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+
+#include "languageservices/lsp/LspLanguageService.h"
+
+#include <QCoreApplication>
+#include <QJsonArray>
+#include <QPair>
+
+#include <initializer_list>
+
+namespace Tw {
+namespace LanguageServices {
+namespace Lsp {
+
+namespace {
+
+QJsonObject jsonObject(const std::initializer_list<QPair<QString, QJsonValue>> & members)
+{
+	QJsonObject object;
+	for (const QPair<QString, QJsonValue> & member : members)
+		object.insert(member.first, member.second);
+	return object;
+}
+
+QJsonArray jsonArray(const std::initializer_list<QJsonValue> & values)
+{
+	QJsonArray array;
+	for (const QJsonValue & value : values)
+		array.append(value);
+	return array;
+}
+
+bool capabilityEnabled(const QJsonValue & value)
+{
+	return value.isObject() || (value.isBool() && value.toBool());
+}
+
+QString errorResponseDescription(const QJsonObject & error)
+{
+	const QString message = error.value(QStringLiteral("message")).toString();
+	return message.isEmpty() ? LspLanguageService::tr("Language server rejected initialization")
+	                         : LspLanguageService::tr("Language server rejected initialization: %1").arg(message);
+}
+
+} // namespace
+
+LspLanguageService::LspLanguageService(const LanguageServiceConfiguration & configuration, QObject * parent,
+	                                   int initializeTimeoutMs, int shutdownTimeoutMs, int terminateTimeoutMs)
+	: LanguageService(parent),
+	  m_configuration(configuration),
+	  m_initializeTimeoutMs(qMax(0, initializeTimeoutMs)),
+	  m_shutdownTimeoutMs(qMax(0, shutdownTimeoutMs)),
+	  m_terminateTimeoutMs(qMax(0, terminateTimeoutMs))
+{
+	m_initializeTimer.setSingleShot(true);
+	m_shutdownTimer.setSingleShot(true);
+
+	connect(&m_process, &LanguageServerProcess::stateChanged, this, [this](LanguageServerProcess::State state) {
+		if (state == LanguageServerProcess::Running && this->state() == Starting)
+			beginInitialize();
+	});
+	connect(m_process.transport(), &JsonRpcTransport::responseReceived, this, &LspLanguageService::handleResponse);
+	connect(m_process.transport(), &JsonRpcTransport::errorResponseReceived, this, &LspLanguageService::handleErrorResponse);
+	connect(m_process.transport(), &JsonRpcTransport::requestReceived, this,
+	        [this](const QJsonValue & id, const QString &, const QJsonValue &) {
+			m_process.transport()->sendErrorResponse(id, -32601, QStringLiteral("Method not found"));
+	        });
+	connect(m_process.transport(), &JsonRpcTransport::pendingRequestFailed, this, &LspLanguageService::handlePendingFailure);
+	connect(&m_process, &LanguageServerProcess::processFinished, this, &LspLanguageService::handleProcessFinished);
+	connect(&m_process, &LanguageServerProcess::processError, this,
+	        [this](QProcess::ProcessError, const QString & description) {
+			if (state() != Stopping && state() != Failed && state() != Stopped)
+				initializationFailed(description);
+	        });
+	connect(&m_process, &LanguageServerProcess::writeFailed, this, [this](const QString & description) {
+		if (state() != Stopping && state() != Failed && state() != Stopped)
+			initializationFailed(description);
+	});
+	connect(&m_initializeTimer, &QTimer::timeout, this, [this]() {
+		initializationFailed(tr("Language server initialization timed out"));
+	});
+	connect(&m_shutdownTimer, &QTimer::timeout, this, &LspLanguageService::sendExitAndStop);
+}
+
+LspLanguageService::~LspLanguageService()
+{
+	m_initializeTimer.stop();
+	m_shutdownTimer.stop();
+}
+
+bool LspLanguageService::start()
+{
+	if (!beginStart())
+		return false;
+	if (m_configuration.executable.isEmpty()) {
+		initializationFailed(tr("Language server is not configured with an executable"));
+		return false;
+	}
+	m_teardownStarted = false;
+	m_initializeRequestId = -1;
+	m_shutdownRequestId = -1;
+	if (!m_process.start(m_configuration.executable, m_configuration.arguments,
+	                     m_configuration.environment, m_configuration.workingDirectory)) {
+		initializationFailed(tr("Could not start the language server process"));
+		return false;
+	}
+	return true;
+}
+
+void LspLanguageService::beginInitialize()
+{
+	setState(Initializing);
+	const QJsonObject clientCapabilities = jsonObject({
+		{QStringLiteral("general"), jsonObject({
+			{QStringLiteral("positionEncodings"), jsonArray({QStringLiteral("utf-16")})}
+		})}
+	});
+	const QJsonObject parameters = jsonObject({
+		{QStringLiteral("processId"), static_cast<double>(QCoreApplication::applicationPid())},
+		{QStringLiteral("rootUri"), QJsonValue(QJsonValue::Null)},
+		{QStringLiteral("capabilities"), clientCapabilities}
+	});
+	m_initializeRequestId = m_process.transport()->sendRequest(QStringLiteral("initialize"), parameters);
+	if (m_initializeRequestId < 0) {
+		initializationFailed(tr("Could not send the language server initialize request"));
+		return;
+	}
+	m_initializeTimer.start(m_initializeTimeoutMs);
+}
+
+void LspLanguageService::handleResponse(qint64 id, const QJsonValue & result)
+{
+	if (id == m_initializeRequestId) {
+		m_initializeRequestId = -1;
+		m_initializeTimer.stop();
+		if (state() != Initializing)
+			return;
+		if (!result.isObject()) {
+			initializationFailed(tr("Language server returned an invalid initialize result"));
+			return;
+		}
+		const QJsonValue capabilitiesValue = result.toObject().value(QStringLiteral("capabilities"));
+		if (!capabilitiesValue.isObject()) {
+			initializationFailed(tr("Language server initialize result has no valid capabilities object"));
+			return;
+		}
+		const QJsonObject capabilities = capabilitiesValue.toObject();
+		const QJsonValue positionEncoding = capabilities.value(QStringLiteral("positionEncoding"));
+		if (!positionEncoding.isUndefined() && (!positionEncoding.isString() || positionEncoding.toString() != QStringLiteral("utf-16"))) {
+			initializationFailed(positionEncoding.isString()
+			                     ? tr("Language server selected unsupported position encoding: %1").arg(positionEncoding.toString())
+			                     : tr("Language server returned an invalid position encoding"));
+			return;
+		}
+		LanguageServiceCapabilities mapped;
+		QString mappingError;
+		if (!mapCapabilities(capabilities, mapped, mappingError)) {
+			initializationFailed(mappingError);
+			return;
+		}
+		if (!m_process.transport()->sendNotification(QStringLiteral("initialized"), QJsonObject{})) {
+			initializationFailed(tr("Could not send the language server initialized notification"));
+			return;
+		}
+		becomeReady(mapped);
+		return;
+	}
+
+	if (id == m_shutdownRequestId) {
+		m_shutdownRequestId = -1;
+		if (state() == Stopping)
+			sendExitAndStop();
+	}
+}
+
+void LspLanguageService::handleErrorResponse(qint64 id, const QJsonObject & error)
+{
+	if (id == m_initializeRequestId) {
+		m_initializeRequestId = -1;
+		m_initializeTimer.stop();
+		if (state() == Initializing)
+			initializationFailed(errorResponseDescription(error));
+	}
+	else if (id == m_shutdownRequestId) {
+		m_shutdownRequestId = -1;
+		if (state() == Stopping)
+			sendExitAndStop();
+	}
+}
+
+void LspLanguageService::handlePendingFailure(qint64 id, const QString & reason)
+{
+	if (id == m_initializeRequestId && state() == Initializing) {
+		m_initializeRequestId = -1;
+		m_initializeTimer.stop();
+		initializationFailed(reason);
+	}
+}
+
+void LspLanguageService::handleProcessFinished(int, QProcess::ExitStatus, bool unexpected)
+{
+	m_initializeTimer.stop();
+	m_shutdownTimer.stop();
+	if (unexpected) {
+		initializationFailed(tr("Language server process exited unexpectedly"));
+		return;
+	}
+	if (state() == Stopping)
+		becomeStopped();
+}
+
+bool LspLanguageService::mapCapabilities(const QJsonObject & capabilities,
+	                                     LanguageServiceCapabilities & mapped, QString & error) const
+{
+	const QJsonValue sync = capabilities.value(QStringLiteral("textDocumentSync"));
+	int syncKind = 0;
+	if (sync.isUndefined() || sync.isNull()) {
+		syncKind = 0;
+	}
+	else if (sync.isDouble()) {
+		const double numeric = sync.toDouble();
+		if (numeric != static_cast<int>(numeric) || numeric < 0 || numeric > 2) {
+			error = tr("Language server returned an invalid text synchronization kind");
+			return false;
+		}
+		syncKind = static_cast<int>(numeric);
+	}
+	else if (sync.isObject()) {
+		const QJsonObject options = sync.toObject();
+		mapped.openClose = options.value(QStringLiteral("openClose")).isBool()
+		                   && options.value(QStringLiteral("openClose")).toBool();
+		const QJsonValue change = options.value(QStringLiteral("change"));
+		if (!change.isUndefined() && !change.isNull()) {
+			if (!change.isDouble() || change.toDouble() != static_cast<int>(change.toDouble())
+			    || change.toDouble() < 0 || change.toDouble() > 2) {
+				error = tr("Language server returned an invalid text synchronization change kind");
+				return false;
+			}
+			syncKind = change.toInt();
+		}
+	}
+	else {
+		error = tr("Language server returned an invalid text synchronization capability");
+		return false;
+	}
+
+	mapped.textSync = syncKind == 1 ? TextSyncKind::Full
+	                : syncKind == 2 ? TextSyncKind::Incremental
+	                                : TextSyncKind::None;
+	mapped.completion = capabilityEnabled(capabilities.value(QStringLiteral("completionProvider")));
+	mapped.signatureHelp = capabilityEnabled(capabilities.value(QStringLiteral("signatureHelpProvider")));
+	mapped.hover = capabilityEnabled(capabilities.value(QStringLiteral("hoverProvider")));
+	mapped.definition = capabilityEnabled(capabilities.value(QStringLiteral("definitionProvider")));
+	mapped.references = capabilityEnabled(capabilities.value(QStringLiteral("referencesProvider")));
+	mapped.documentSymbols = capabilityEnabled(capabilities.value(QStringLiteral("documentSymbolProvider")));
+	mapped.workspaceSymbols = capabilityEnabled(capabilities.value(QStringLiteral("workspaceSymbolProvider")));
+	// Neither push diagnostics nor pull diagnostics are consumed in this cycle.
+	mapped.diagnostics = false;
+	return true;
+}
+
+void LspLanguageService::initializationFailed(const QString & reason)
+{
+	if (state() == Failed || state() == Stopped)
+		return;
+	m_initializeTimer.stop();
+	m_shutdownTimer.stop();
+	becomeFailed(reason);
+	beginProcessStop();
+}
+
+void LspLanguageService::stop()
+{
+	if (state() == Stopped || state() == NotConfigured || state() == Stopping)
+		return;
+	if (state() == Failed) {
+		beginProcessStop();
+		return;
+	}
+	const bool wasReady = state() == Ready;
+	setState(Stopping);
+	m_initializeTimer.stop();
+	if (!wasReady) {
+		beginProcessStop();
+		return;
+	}
+	m_shutdownRequestId = m_process.transport()->sendRequest(QStringLiteral("shutdown"));
+	if (m_shutdownRequestId < 0) {
+		sendExitAndStop();
+		return;
+	}
+	m_shutdownTimer.start(m_shutdownTimeoutMs);
+}
+
+void LspLanguageService::sendExitAndStop()
+{
+	if (m_teardownStarted)
+		return;
+	m_shutdownTimer.stop();
+	m_process.transport()->sendNotification(QStringLiteral("exit"));
+	beginProcessStop();
+}
+
+void LspLanguageService::beginProcessStop()
+{
+	if (m_teardownStarted)
+		return;
+	m_teardownStarted = true;
+	m_process.stop(m_shutdownTimeoutMs, m_terminateTimeoutMs);
+	if (m_process.state() == LanguageServerProcess::NotRunning && state() == Stopping)
+		becomeStopped();
+}
+
+} // namespace Lsp
+} // namespace LanguageServices
+} // namespace Tw

--- a/src/languageservices/lsp/LspLanguageService.cpp
+++ b/src/languageservices/lsp/LspLanguageService.cpp
@@ -296,12 +296,14 @@ void LspLanguageService::handleProcessFinished(int, QProcess::ExitStatus, bool u
 {
 	m_initializeTimer.stop();
 	m_shutdownTimer.stop();
+	if (state() == Stopping) {
+		becomeStopped();
+		return;
+	}
 	if (unexpected) {
 		initializationFailed(tr("Language server process exited unexpectedly"));
 		return;
 	}
-	if (state() == Stopping)
-		becomeStopped();
 }
 
 bool LspLanguageService::mapCapabilities(const QJsonObject & capabilities,
@@ -371,6 +373,12 @@ void LspLanguageService::stop()
 	if (state() == Stopped || state() == NotConfigured || state() == Stopping)
 		return;
 	if (state() == Failed) {
+		setState(Stopping);
+		if (m_teardownStarted) {
+			if (!m_process.isRunning())
+				becomeStopped();
+			return;
+		}
 		beginProcessStop();
 		return;
 	}

--- a/src/languageservices/lsp/LspLanguageService.h
+++ b/src/languageservices/lsp/LspLanguageService.h
@@ -1,0 +1,67 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+#ifndef LSPLANGUAGESERVICE_H
+#define LSPLANGUAGESERVICE_H
+
+#include "languageservices/LanguageService.h"
+#include "languageservices/LanguageServiceConfiguration.h"
+#include "languageservices/lsp/LanguageServerProcess.h"
+
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QTimer>
+
+namespace Tw {
+namespace LanguageServices {
+namespace Lsp {
+
+class LspLanguageService : public LanguageService
+{
+	Q_OBJECT
+
+public:
+	explicit LspLanguageService(const LanguageServiceConfiguration & configuration,
+	                            QObject * parent = nullptr,
+	                            int initializeTimeoutMs = 5000,
+	                            int shutdownTimeoutMs = 1000,
+	                            int terminateTimeoutMs = 1000);
+	~LspLanguageService() override;
+
+	bool start() override;
+	void stop() override;
+
+private:
+	void beginInitialize();
+	void handleResponse(qint64 id, const QJsonValue & result);
+	void handleErrorResponse(qint64 id, const QJsonObject & error);
+	void handlePendingFailure(qint64 id, const QString & reason);
+	void handleProcessFinished(int exitCode, QProcess::ExitStatus exitStatus, bool unexpected);
+	bool mapCapabilities(const QJsonObject & capabilities, LanguageServiceCapabilities & mapped, QString & error) const;
+	void initializationFailed(const QString & reason);
+	void beginProcessStop();
+	void sendExitAndStop();
+
+	LanguageServiceConfiguration m_configuration;
+	LanguageServerProcess m_process;
+	QTimer m_initializeTimer;
+	QTimer m_shutdownTimer;
+	qint64 m_initializeRequestId{-1};
+	qint64 m_shutdownRequestId{-1};
+	int m_initializeTimeoutMs;
+	int m_shutdownTimeoutMs;
+	int m_terminateTimeoutMs;
+	bool m_teardownStarted{false};
+};
+
+} // namespace Lsp
+} // namespace LanguageServices
+} // namespace Tw
+
+#endif // LSPLANGUAGESERVICE_H

--- a/src/languageservices/lsp/LspLanguageService.h
+++ b/src/languageservices/lsp/LspLanguageService.h
@@ -14,6 +14,7 @@
 #include "languageservices/LanguageServiceConfiguration.h"
 #include "languageservices/lsp/LanguageServerProcess.h"
 
+#include <QHash>
 #include <QJsonObject>
 #include <QJsonValue>
 #include <QTimer>
@@ -36,6 +37,11 @@ public:
 
 	bool start() override;
 	void stop() override;
+	bool openDocument(const LanguageDocumentOpen & document) override;
+	bool changeDocument(const QUrl & url, quint64 version, const LanguageDocumentChange & change) override;
+	bool closeDocument(const QUrl & url) override;
+	bool requestCompletion(const LanguageCompletionRequest & request) override;
+	bool requestDefinition(const LanguageDefinitionRequest & request) override;
 
 private:
 	void beginInitialize();
@@ -47,6 +53,10 @@ private:
 	void initializationFailed(const QString & reason);
 	void beginProcessStop();
 	void sendExitAndStop();
+	void failCompletionRequests(const QString & reason);
+	void failDefinitionRequests(const QString & reason);
+	bool mapCompletionResult(const QJsonValue & result, QList<CompletionItem> & items) const;
+	bool mapDefinitionResult(const QJsonValue & result, QList<LanguageLocation> & locations) const;
 
 	LanguageServiceConfiguration m_configuration;
 	LanguageServerProcess m_process;
@@ -54,6 +64,8 @@ private:
 	QTimer m_shutdownTimer;
 	qint64 m_initializeRequestId{-1};
 	qint64 m_shutdownRequestId{-1};
+	QHash<qint64, quint64> m_completionRequests;
+	QHash<qint64, quint64> m_definitionRequests;
 	int m_initializeTimeoutMs;
 	int m_shutdownTimeoutMs;
 	int m_terminateTimeoutMs;

--- a/unit-tests/CMakeLists.txt
+++ b/unit-tests/CMakeLists.txt
@@ -71,6 +71,46 @@ ENDIF ()
 add_executable(byte_echo_test byte_echo_test.cpp)
 target_compile_options(byte_echo_test PRIVATE ${WARNING_OPTIONS})
 
+# Language-server transport
+add_executable(language_server_fake language_server_fake.cpp)
+target_compile_options(language_server_fake PRIVATE ${WARNING_OPTIONS})
+target_link_libraries(language_server_fake ${QT_LIBRARIES})
+
+add_executable(test_LanguageServerTransport
+	LanguageServerTransport_test.cpp
+	LanguageServerTransport_test.h
+	"${CMAKE_SOURCE_DIR}/src/languageservices/lsp/JsonRpcTransport.cpp"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/lsp/JsonRpcTransport.h"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/lsp/LanguageServerProcess.cpp"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/lsp/LanguageServerProcess.h"
+)
+target_compile_options(test_LanguageServerTransport PRIVATE ${WARNING_OPTIONS})
+target_link_libraries(test_LanguageServerTransport ${QT_LIBRARIES})
+add_dependencies(test_LanguageServerTransport language_server_fake)
+add_test(NAME test_LanguageServerTransport COMMAND test_LanguageServerTransport)
+
+# Provider-neutral language-service session and LSP adapter
+add_executable(test_LanguageServiceSession
+	LanguageServiceSession_test.cpp
+	LanguageServiceSession_test.h
+	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageService.cpp"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageService.h"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageServiceConfiguration.h"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageServiceManager.cpp"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageServiceManager.h"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageServiceTypes.h"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/lsp/JsonRpcTransport.cpp"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/lsp/JsonRpcTransport.h"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/lsp/LanguageServerProcess.cpp"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/lsp/LanguageServerProcess.h"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/lsp/LspLanguageService.cpp"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/lsp/LspLanguageService.h"
+)
+target_compile_options(test_LanguageServiceSession PRIVATE ${WARNING_OPTIONS})
+target_link_libraries(test_LanguageServiceSession ${QT_LIBRARIES})
+add_dependencies(test_LanguageServiceSession language_server_fake)
+add_test(NAME test_LanguageServiceSession COMMAND test_LanguageServiceSession)
+
 # UI
 add_executable(test_UI
 	UI_test.cpp

--- a/unit-tests/CMakeLists.txt
+++ b/unit-tests/CMakeLists.txt
@@ -170,6 +170,7 @@ target_compile_options(test_LanguageServiceNavigationWindow PRIVATE ${WARNING_OP
 target_include_directories(test_LanguageServiceNavigationWindow PRIVATE "${TEXWORKS_WINDOW_TEST_BINARY_DIR}")
 target_link_libraries(test_LanguageServiceNavigationWindow ${TEXWORKS_WINDOW_TEST_LIBRARIES})
 add_dependencies(test_LanguageServiceNavigationWindow GitRev)
+add_dependencies(test_LanguageServiceNavigationWindow language_server_fake)
 add_test(NAME test_LanguageServiceNavigationWindow COMMAND test_LanguageServiceNavigationWindow)
 
 # UI

--- a/unit-tests/CMakeLists.txt
+++ b/unit-tests/CMakeLists.txt
@@ -8,6 +8,28 @@ target_compile_options(test_BibTeXFile PRIVATE ${WARNING_OPTIONS})
 target_link_libraries(test_BibTeXFile ${QT_LIBRARIES} ${ZLIB_LIBRARIES} ${TEXWORKS_ADDITIONAL_LIBS})
 add_test(NAME test_BibTeXFile COMMAND test_BibTeXFile WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/testcases")
 
+# DefaultFileFilters
+add_executable(test_DefaultFileFilters
+	DefaultFileFilters_test.cpp
+	DefaultFileFilters_test.h
+	"${CMAKE_SOURCE_DIR}/src/DefaultFileFilters.cpp"
+	"${CMAKE_SOURCE_DIR}/src/DefaultFileFilters.h"
+)
+target_compile_options(test_DefaultFileFilters PRIVATE ${WARNING_OPTIONS})
+target_link_libraries(test_DefaultFileFilters ${QT_LIBRARIES} ${ZLIB_LIBRARIES} ${TEXWORKS_ADDITIONAL_LIBS})
+add_test(NAME test_DefaultFileFilters COMMAND test_DefaultFileFilters)
+
+# DefaultEngineList
+add_executable(test_DefaultEngineList
+	DefaultEngineList_test.cpp
+	DefaultEngineList_test.h
+	"${CMAKE_SOURCE_DIR}/src/DefaultEngineList.cpp"
+	"${CMAKE_SOURCE_DIR}/src/DefaultEngineList.h"
+)
+target_compile_options(test_DefaultEngineList PRIVATE ${WARNING_OPTIONS})
+target_link_libraries(test_DefaultEngineList ${QT_LIBRARIES} ${ZLIB_LIBRARIES} ${TEXWORKS_ADDITIONAL_LIBS})
+add_test(NAME test_DefaultEngineList COMMAND test_DefaultEngineList)
+
 # Scripting
 add_executable(test_Scripting
 	Scripting_test.cpp
@@ -111,4 +133,3 @@ if (WITH_POPPLERQT)
 endif (WITH_POPPLERQT)
 target_link_libraries(test_Document QtPDF::qtpdf SyncTeX::synctex Hunspell::hunspell ${QT_LIBRARIES} ${ZLIB_LIBRARIES} ${TEXWORKS_ADDITIONAL_LIBS})
 add_test(NAME test_Document COMMAND test_Document WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/testcases")
-

--- a/unit-tests/CMakeLists.txt
+++ b/unit-tests/CMakeLists.txt
@@ -95,6 +95,8 @@ add_executable(test_LanguageServiceSession
 	LanguageServiceSession_test.h
 	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageService.cpp"
 	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageService.h"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageServiceDocumentBinding.cpp"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageServiceDocumentBinding.h"
 	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageServiceConfiguration.h"
 	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageServiceManager.cpp"
 	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageServiceManager.h"
@@ -105,11 +107,70 @@ add_executable(test_LanguageServiceSession
 	"${CMAKE_SOURCE_DIR}/src/languageservices/lsp/LanguageServerProcess.h"
 	"${CMAKE_SOURCE_DIR}/src/languageservices/lsp/LspLanguageService.cpp"
 	"${CMAKE_SOURCE_DIR}/src/languageservices/lsp/LspLanguageService.h"
+	"${CMAKE_SOURCE_DIR}/src/document/TextDocument.cpp"
+	"${CMAKE_SOURCE_DIR}/src/document/TextDocument.h"
+	"${CMAKE_SOURCE_DIR}/src/document/TeXDocument.cpp"
+	"${CMAKE_SOURCE_DIR}/src/document/TeXDocument.h"
+	"${CMAKE_SOURCE_DIR}/src/TeXHighlighter.h"
+	LanguageServiceDocument_test_support.cpp
 )
 target_compile_options(test_LanguageServiceSession PRIVATE ${WARNING_OPTIONS})
 target_link_libraries(test_LanguageServiceSession ${QT_LIBRARIES})
 add_dependencies(test_LanguageServiceSession language_server_fake)
 add_test(NAME test_LanguageServiceSession COMMAND test_LanguageServiceSession)
+
+# Provider-neutral document lifecycle and synchronization
+add_executable(test_LanguageServiceDocument
+	LanguageServiceDocument_test.cpp
+	LanguageServiceDocument_test.h
+	LanguageServiceDocument_test_support.cpp
+	"${CMAKE_SOURCE_DIR}/src/document/TextDocument.cpp"
+	"${CMAKE_SOURCE_DIR}/src/document/TextDocument.h"
+	"${CMAKE_SOURCE_DIR}/src/document/TeXDocument.cpp"
+	"${CMAKE_SOURCE_DIR}/src/document/TeXDocument.h"
+	"${CMAKE_SOURCE_DIR}/src/TeXHighlighter.h"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageService.cpp"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageService.h"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageServiceDocumentBinding.cpp"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageServiceDocumentBinding.h"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageServiceManager.cpp"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageServiceManager.h"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageServiceNavigation.cpp"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageServiceNavigation.h"
+	"${CMAKE_SOURCE_DIR}/src/languageservices/LanguageServiceTypes.h"
+)
+target_compile_options(test_LanguageServiceDocument PRIVATE ${WARNING_OPTIONS})
+target_link_libraries(test_LanguageServiceDocument ${QT_LIBRARIES})
+add_test(NAME test_LanguageServiceDocument COMMAND test_LanguageServiceDocument)
+
+# Go-to-definition source-window action and navigation integration
+get_target_property(TEXWORKS_WINDOW_TEST_SOURCES TeXworks SOURCES)
+set(TEXWORKS_WINDOW_TEST_SOURCE_DIR "${PROJECT_SOURCE_DIR}/src")
+set(TEXWORKS_WINDOW_TEST_BINARY_DIR "${PROJECT_BINARY_DIR}/src")
+set(TEXWORKS_WINDOW_TEST_RESOLVED_SOURCES)
+foreach(source ${TEXWORKS_WINDOW_TEST_SOURCES})
+	if (IS_ABSOLUTE "${source}")
+		set(resolved_source "${source}")
+	elseif (EXISTS "${TEXWORKS_WINDOW_TEST_SOURCE_DIR}/${source}")
+		set(resolved_source "${TEXWORKS_WINDOW_TEST_SOURCE_DIR}/${source}")
+	else()
+		set(resolved_source "${TEXWORKS_WINDOW_TEST_BINARY_DIR}/${source}")
+	endif()
+	if (NOT resolved_source MATCHES "/main\\.cpp$")
+		list(APPEND TEXWORKS_WINDOW_TEST_RESOLVED_SOURCES "${resolved_source}")
+	endif()
+endforeach()
+get_target_property(TEXWORKS_WINDOW_TEST_LIBRARIES TeXworks LINK_LIBRARIES)
+add_executable(test_LanguageServiceNavigationWindow
+	LanguageServiceNavigationWindow_test.cpp
+	LanguageServiceNavigationWindow_test.h
+	${TEXWORKS_WINDOW_TEST_RESOLVED_SOURCES}
+)
+target_compile_options(test_LanguageServiceNavigationWindow PRIVATE ${WARNING_OPTIONS})
+target_include_directories(test_LanguageServiceNavigationWindow PRIVATE "${TEXWORKS_WINDOW_TEST_BINARY_DIR}")
+target_link_libraries(test_LanguageServiceNavigationWindow ${TEXWORKS_WINDOW_TEST_LIBRARIES})
+add_dependencies(test_LanguageServiceNavigationWindow GitRev)
+add_test(NAME test_LanguageServiceNavigationWindow COMMAND test_LanguageServiceNavigationWindow)
 
 # UI
 add_executable(test_UI
@@ -124,6 +185,7 @@ add_executable(test_UI
 )
 target_compile_options(test_UI PRIVATE ${WARNING_OPTIONS})
 target_link_libraries(test_UI ${QT_LIBRARIES} ${ZLIB_LIBRARIES} ${TEXWORKS_ADDITIONAL_LIBS})
+add_dependencies(test_UI byte_echo_test)
 add_test(NAME test_UI COMMAND test_UI WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/testcases")
 
 # Utils

--- a/unit-tests/DefaultEngineList_test.cpp
+++ b/unit-tests/DefaultEngineList_test.cpp
@@ -1,0 +1,121 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  Jonathan Kew, Stefan Löffler, Charlie Sharpsteen
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+	For links to further information, or to contact the authors,
+	see <https://tug.org/texworks/>.
+*/
+
+#include "DefaultEngineList_test.h"
+#include "DefaultEngineList.h"
+
+namespace {
+
+const Tw::DefaultEngineList::Definition * findDefinition(const QList<Tw::DefaultEngineList::Definition> & definitions, const QString & name)
+{
+	for (const Tw::DefaultEngineList::Definition & definition : definitions) {
+		if (definition.name == name) {
+			return &definition;
+		}
+	}
+	return nullptr;
+}
+
+int definitionCount(const QList<Tw::DefaultEngineList::Definition> & definitions, const QString & name)
+{
+	int count{0};
+	for (const Tw::DefaultEngineList::Definition & definition : definitions) {
+		if (definition.name == name) {
+			++count;
+		}
+	}
+	return count;
+}
+
+#if defined(Q_OS_WIN)
+const QString contextProgram{QStringLiteral("context.exe")};
+const QString texexecProgram{QStringLiteral("texexec.exe")};
+#else
+const QString contextProgram{QStringLiteral("context")};
+const QString texexecProgram{QStringLiteral("texexec")};
+#endif
+
+} // namespace
+
+namespace UnitTest {
+
+void TestDefaultEngineList::contextLuaMetaTeX()
+{
+	const QList<Tw::DefaultEngineList::Definition> definitions{Tw::DefaultEngineList::definitions()};
+	const QString name{QStringLiteral("ConTeXt (LuaMetaTeX)")};
+	QCOMPARE(definitionCount(definitions, name), 1);
+	const Tw::DefaultEngineList::Definition * definition{findDefinition(definitions, name)};
+	QVERIFY(definition != nullptr);
+	QCOMPARE(definition->program, contextProgram);
+	QCOMPARE(definition->arguments, QStringList({QStringLiteral("--synctex=repeat"), QStringLiteral("$fullname")}));
+	QVERIFY(definition->arguments.contains(QStringLiteral("--luatex")) == false);
+	QVERIFY(definition->showPdf);
+	QCOMPARE(definition->sourceLanguage, QStringLiteral("context"));
+}
+
+void TestDefaultEngineList::contextLuaTeX()
+{
+	const QList<Tw::DefaultEngineList::Definition> definitions{Tw::DefaultEngineList::definitions()};
+	const QString name{QStringLiteral("ConTeXt (LuaTeX)")};
+	QCOMPARE(definitionCount(definitions, name), 1);
+	const Tw::DefaultEngineList::Definition * definition{findDefinition(definitions, name)};
+	QVERIFY(definition != nullptr);
+	QCOMPARE(definition->program, contextProgram);
+	QCOMPARE(definition->arguments, QStringList({QStringLiteral("--synctex=repeat"), QStringLiteral("--luatex"), QStringLiteral("$fullname")}));
+	QVERIFY(definition->showPdf);
+	QCOMPARE(definition->sourceLanguage, QStringLiteral("context"));
+}
+
+void TestDefaultEngineList::contextDefinitionsAreDistinct()
+{
+	const QList<Tw::DefaultEngineList::Definition> definitions{Tw::DefaultEngineList::definitions()};
+	const Tw::DefaultEngineList::Definition * luaMetaTeX{findDefinition(definitions, QStringLiteral("ConTeXt (LuaMetaTeX)"))};
+	const Tw::DefaultEngineList::Definition * luaTeX{findDefinition(definitions, QStringLiteral("ConTeXt (LuaTeX)"))};
+	QVERIFY(luaMetaTeX != nullptr);
+	QVERIFY(luaTeX != nullptr);
+	QVERIFY(luaMetaTeX->name != luaTeX->name);
+	QVERIFY(luaMetaTeX->arguments != luaTeX->arguments);
+}
+
+void TestDefaultEngineList::historicalContextEngines()
+{
+	const QList<Tw::DefaultEngineList::Definition> definitions{Tw::DefaultEngineList::definitions()};
+	const Tw::DefaultEngineList::Definition * pdfTeX{findDefinition(definitions, QStringLiteral("ConTeXt (pdfTeX)"))};
+	const Tw::DefaultEngineList::Definition * xeTeX{findDefinition(definitions, QStringLiteral("ConTeXt (XeTeX)"))};
+	QVERIFY(pdfTeX != nullptr);
+	QVERIFY(xeTeX != nullptr);
+	QCOMPARE(pdfTeX->program, texexecProgram);
+	QCOMPARE(pdfTeX->arguments, QStringList({QStringLiteral("--synctex"), QStringLiteral("$fullname")}));
+	QVERIFY(pdfTeX->showPdf);
+	QCOMPARE(pdfTeX->sourceLanguage, QStringLiteral("context"));
+	QCOMPARE(xeTeX->program, texexecProgram);
+	QCOMPARE(xeTeX->arguments, QStringList({QStringLiteral("--synctex"), QStringLiteral("--xtx"), QStringLiteral("$fullname")}));
+	QVERIFY(xeTeX->showPdf);
+	QCOMPARE(xeTeX->sourceLanguage, QStringLiteral("context"));
+
+	const Tw::DefaultEngineList::Definition * pdfLaTeX{findDefinition(definitions, QStringLiteral("pdfLaTeX"))};
+	QVERIFY(pdfLaTeX != nullptr);
+	QVERIFY(pdfLaTeX->sourceLanguage.isEmpty());
+}
+
+} // namespace UnitTest
+
+QTEST_APPLESS_MAIN(UnitTest::TestDefaultEngineList)

--- a/unit-tests/DefaultEngineList_test.h
+++ b/unit-tests/DefaultEngineList_test.h
@@ -1,0 +1,37 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  Jonathan Kew, Stefan Löffler, Charlie Sharpsteen
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+	For links to further information, or to contact the authors,
+	see <https://tug.org/texworks/>.
+*/
+
+#include <QtTest/QtTest>
+
+namespace UnitTest {
+
+class TestDefaultEngineList : public QObject
+{
+	Q_OBJECT
+
+private slots:
+	void contextLuaMetaTeX();
+	void contextLuaTeX();
+	void contextDefinitionsAreDistinct();
+	void historicalContextEngines();
+};
+
+} // namespace UnitTest

--- a/unit-tests/DefaultFileFilters_test.cpp
+++ b/unit-tests/DefaultFileFilters_test.cpp
@@ -1,0 +1,92 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  Jonathan Kew, Stefan Löffler, Charlie Sharpsteen
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+	For links to further information, or to contact the authors,
+	see <https://tug.org/texworks/>.
+*/
+
+#include "DefaultFileFilters_test.h"
+#include "DefaultFileFilters.h"
+
+#include <QDir>
+#include <QFileInfo>
+
+namespace UnitTest {
+
+void TestDefaultFileFilters::texDocumentClassification_data()
+{
+	QTest::addColumn<QString>("fileName");
+	QTest::addColumn<bool>("isTeXDocument");
+
+	QTest::newRow("tex") << QStringLiteral("example.tex") << true;
+	QTest::newRow("mkiv") << QStringLiteral("example.mkiv") << true;
+	QTest::newRow("mkxl") << QStringLiteral("example.mkxl") << true;
+	QTest::newRow("uppercase-mkxl") << QStringLiteral("example.MKXL") << true;
+	QTest::newRow("unrelated") << QStringLiteral("example.cpp") << false;
+}
+
+void TestDefaultFileFilters::texDocumentClassification()
+{
+	QFETCH(QString, fileName);
+	QFETCH(bool, isTeXDocument);
+
+	QCOMPARE(QDir::match(Tw::DefaultFileFilters::texDocumentNameFilters(), QFileInfo(fileName).fileName()), isTeXDocument);
+}
+
+void TestDefaultFileFilters::texDocumentFilter()
+{
+	const QStringList filters{Tw::DefaultFileFilters::filters()};
+	QVERIFY(!filters.isEmpty());
+	const QString & texFilter{filters.first()};
+
+	const QString::size_type texPosition{texFilter.indexOf(QStringLiteral("*.tex"))};
+	const QString::size_type mkivPosition{texFilter.indexOf(QStringLiteral("*.mkiv"))};
+	const QString::size_type mkxlPosition{texFilter.indexOf(QStringLiteral("*.mkxl"))};
+	QVERIFY(texPosition >= 0);
+	QVERIFY(mkivPosition > texPosition);
+	QVERIFY(mkxlPosition > mkivPosition);
+}
+
+void TestDefaultFileFilters::neighboringFiltersPreserved()
+{
+	const QStringList filters{Tw::DefaultFileFilters::filters()};
+	QVERIFY(filters.contains(QObject::tr("LaTeX documents (*.ltx)")));
+	QVERIFY(filters.contains(QObject::tr("BibTeX databases (*.bib)")));
+	QVERIFY(filters.contains(QObject::tr("Style files (*.sty)")));
+	QVERIFY(filters.contains(QObject::tr("Class files (*.cls)")));
+	QVERIFY(filters.contains(QObject::tr("Documented macros (*.dtx)")));
+	QVERIFY(filters.contains(QObject::tr("PDF documents (*.pdf)")));
+}
+
+void TestDefaultFileFilters::defaultFilterSelection()
+{
+	const QStringList filters{Tw::DefaultFileFilters::filters()};
+	QCOMPARE(Tw::DefaultFileFilters::chooseForFile(QStringLiteral("example.tex"), filters), filters.first());
+	QCOMPARE(Tw::DefaultFileFilters::chooseForFile(QStringLiteral("example.mkiv"), filters), filters.last());
+	QCOMPARE(Tw::DefaultFileFilters::chooseForFile(QStringLiteral("example.mkxl"), filters), filters.last());
+	QCOMPARE(Tw::DefaultFileFilters::chooseForFile(QStringLiteral("example.ltx"), filters), QObject::tr("LaTeX documents (*.ltx)"));
+}
+
+void TestDefaultFileFilters::defaultFilterSelectionIsCaseSensitive()
+{
+	const QStringList filters{Tw::DefaultFileFilters::filters()};
+	QCOMPARE(Tw::DefaultFileFilters::chooseForFile(QStringLiteral("example.TEX"), filters), filters.last());
+}
+
+} // namespace UnitTest
+
+QTEST_APPLESS_MAIN(UnitTest::TestDefaultFileFilters)

--- a/unit-tests/DefaultFileFilters_test.h
+++ b/unit-tests/DefaultFileFilters_test.h
@@ -1,0 +1,44 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  Jonathan Kew, Stefan Löffler, Charlie Sharpsteen
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+	For links to further information, or to contact the authors,
+	see <https://tug.org/texworks/>.
+*/
+
+#ifndef DEFAULTFILEFILTERS_TEST_H
+#define DEFAULTFILEFILTERS_TEST_H
+
+#include <QtTest/QtTest>
+
+namespace UnitTest {
+
+class TestDefaultFileFilters : public QObject
+{
+	Q_OBJECT
+
+private slots:
+	void texDocumentClassification_data();
+	void texDocumentClassification();
+	void texDocumentFilter();
+	void neighboringFiltersPreserved();
+	void defaultFilterSelection();
+	void defaultFilterSelectionIsCaseSensitive();
+};
+
+} // namespace UnitTest
+
+#endif // DEFAULTFILEFILTERS_TEST_H

--- a/unit-tests/LanguageServerTransport_test.cpp
+++ b/unit-tests/LanguageServerTransport_test.cpp
@@ -1,0 +1,530 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+	For links to further information, or to contact the authors,
+	see <https://tug.org/texworks/>.
+*/
+
+#include "LanguageServerTransport_test.h"
+
+#include "languageservices/lsp/JsonRpcTransport.h"
+#include "languageservices/lsp/LanguageServerProcess.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QElapsedTimer>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QPair>
+#include <QSignalSpy>
+#include <QTimer>
+#include <QtTest>
+
+#include <initializer_list>
+
+using Tw::LanguageServices::Lsp::JsonRpcTransport;
+using Tw::LanguageServices::Lsp::LanguageServerProcess;
+
+namespace {
+
+QJsonObject jsonObject(std::initializer_list<QPair<QString, QJsonValue>> values)
+{
+	QJsonObject object;
+	for (const QPair<QString, QJsonValue> & value : values)
+		object.insert(value.first, value.second);
+	return object;
+}
+
+QJsonArray jsonArray(std::initializer_list<QJsonValue> values)
+{
+	QJsonArray array;
+	for (const QJsonValue & value : values)
+		array.append(value);
+	return array;
+}
+
+QJsonObject notification(const QString & method, const QJsonValue & params = QJsonValue(QJsonValue::Undefined))
+{
+	QJsonObject message = jsonObject({
+		{QStringLiteral("jsonrpc"), QStringLiteral("2.0")},
+		{QStringLiteral("method"), method}
+	});
+	if (!params.isUndefined())
+		message.insert(QStringLiteral("params"), params);
+	return message;
+}
+
+QByteArray framedBody(const QByteArray & body, const QByteArray & headerName = QByteArrayLiteral("Content-Length"),
+	                  const QByteArray & additionalHeader = {})
+{
+	QByteArray header = headerName + QByteArrayLiteral(": ") + QByteArray::number(body.size()) + QByteArrayLiteral("\r\n");
+	if (!additionalHeader.isEmpty())
+		header += additionalHeader + QByteArrayLiteral("\r\n");
+	return header + QByteArrayLiteral("\r\n") + body;
+}
+
+QJsonObject framedObject(const QByteArray & bytes)
+{
+	const auto bodyStart = bytes.indexOf("\r\n\r\n");
+	if (bodyStart < 0)
+		return {};
+	return QJsonDocument::fromJson(bytes.mid(bodyStart + 4)).object();
+}
+
+bool hasByteCorrectContentLength(const QByteArray & bytes)
+{
+	const auto bodyStart = bytes.indexOf("\r\n\r\n");
+	if (bodyStart < 0)
+		return false;
+	bool found = false;
+	qlonglong contentLength = -1;
+	for (QByteArray line : bytes.left(bodyStart).split('\n')) {
+		if (line.endsWith('\r'))
+			line.chop(1);
+		const auto colon = line.indexOf(':');
+		if (colon <= 0 || line.left(colon).trimmed().toLower() != QByteArrayLiteral("content-length"))
+			continue;
+		if (found)
+			return false;
+		bool ok = false;
+		contentLength = line.mid(colon + 1).trimmed().toLongLong(&ok, 10);
+		if (!ok)
+			return false;
+		found = true;
+	}
+	return found && contentLength == bytes.size() - bodyStart - 4;
+}
+
+QString fakeServerPath()
+{
+	QString name = QStringLiteral("language_server_fake");
+#ifdef Q_OS_WIN
+	name += QStringLiteral(".exe");
+#endif
+	return QDir(QCoreApplication::applicationDirPath()).filePath(name);
+}
+
+void waitForRunning(LanguageServerProcess & process)
+{
+	QTRY_COMPARE(process.state(), LanguageServerProcess::Running);
+}
+
+} // namespace
+
+void LanguageServerTransportTest::initTestCase()
+{
+	qRegisterMetaType<QProcess::ExitStatus>("QProcess::ExitStatus");
+	qRegisterMetaType<QProcess::ProcessError>("QProcess::ProcessError");
+	qRegisterMetaType<LanguageServerProcess::State>("Tw::LanguageServices::Lsp::LanguageServerProcess::State");
+	QVERIFY2(QFileInfo::exists(fakeServerPath()), qPrintable(fakeServerPath()));
+}
+
+void LanguageServerTransportTest::markTimerFired()
+{
+	m_timerFired = true;
+}
+
+void LanguageServerTransportTest::completeFrame()
+{
+	JsonRpcTransport transport;
+	QSignalSpy notificationSpy(&transport, SIGNAL(notificationReceived(const QString &, const QJsonValue &)));
+	transport.receiveData(JsonRpcTransport::frame(notification(QStringLiteral("one"))));
+	QCOMPARE(notificationSpy.count(), 1);
+	QCOMPARE(notificationSpy.takeFirst().at(0).toString(), QStringLiteral("one"));
+}
+
+void LanguageServerTransportTest::fragmentedHeader()
+{
+	JsonRpcTransport transport;
+	QSignalSpy spy(&transport, SIGNAL(notificationReceived(const QString &, const QJsonValue &)));
+	const QByteArray bytes = JsonRpcTransport::frame(notification(QStringLiteral("header")));
+	for (char byte : bytes.left(18))
+		transport.receiveData(QByteArray(1, byte));
+	QCOMPARE(spy.count(), 0);
+	transport.receiveData(bytes.mid(18));
+	QCOMPARE(spy.count(), 1);
+}
+
+void LanguageServerTransportTest::fragmentedBody()
+{
+	JsonRpcTransport transport;
+	QSignalSpy spy(&transport, SIGNAL(notificationReceived(const QString &, const QJsonValue &)));
+	const QByteArray bytes = JsonRpcTransport::frame(notification(QStringLiteral("body")));
+	const auto split = bytes.indexOf("\r\n\r\n") + 6;
+	transport.receiveData(bytes.left(split));
+	QCOMPARE(spy.count(), 0);
+	transport.receiveData(bytes.mid(split));
+	QCOMPARE(spy.count(), 1);
+}
+
+void LanguageServerTransportTest::severalFramesAndTrailingPartial()
+{
+	JsonRpcTransport transport;
+	QSignalSpy spy(&transport, SIGNAL(notificationReceived(const QString &, const QJsonValue &)));
+	const QByteArray first = JsonRpcTransport::frame(notification(QStringLiteral("first")));
+	const QByteArray second = JsonRpcTransport::frame(notification(QStringLiteral("second")));
+	const QByteArray third = JsonRpcTransport::frame(notification(QStringLiteral("third")));
+	transport.receiveData(first + second + third.left(9));
+	QCOMPARE(spy.count(), 2);
+	transport.receiveData(third.mid(9));
+	QCOMPARE(spy.count(), 3);
+	QCOMPARE(spy.at(2).at(0).toString(), QStringLiteral("third"));
+}
+
+void LanguageServerTransportTest::caseInsensitiveAndAdditionalHeader()
+{
+	JsonRpcTransport transport;
+	QSignalSpy spy(&transport, SIGNAL(notificationReceived(const QString &, const QJsonValue &)));
+	const QByteArray body = QJsonDocument(notification(QStringLiteral("headers"))).toJson(QJsonDocument::Compact);
+	transport.receiveData(framedBody(body, QByteArrayLiteral("cOnTeNt-LeNgTh"), QByteArrayLiteral("Content-Type: application/vscode-jsonrpc; charset=utf-8")));
+	QCOMPARE(spy.count(), 1);
+}
+
+void LanguageServerTransportTest::malformedLengths_data()
+{
+	QTest::addColumn<QByteArray>("input");
+	QTest::addColumn<QString>("errorFragment");
+	QTest::newRow("missing") << QByteArrayLiteral("Content-Type: application/json\r\n\r\n{}") << QStringLiteral("Missing");
+	QTest::newRow("non-numeric") << QByteArrayLiteral("Content-Length: twelve\r\n\r\n") << QStringLiteral("Invalid");
+	QTest::newRow("negative") << QByteArrayLiteral("Content-Length: -1\r\n\r\n") << QStringLiteral("Invalid");
+	QTest::newRow("oversized") << QByteArrayLiteral("Content-Length: 8388609\r\n\r\n") << QStringLiteral("exceeds");
+	QTest::newRow("duplicate") << QByteArrayLiteral("Content-Length: 2\r\nContent-Length: 2\r\n\r\n{}") << QStringLiteral("Duplicate");
+	QTest::newRow("malformed-header") << QByteArrayLiteral("Content-Length 2\r\n\r\n{}") << QStringLiteral("Malformed");
+	QTest::newRow("oversized-header") << (QByteArrayLiteral("X-Test: ") + QByteArray(JsonRpcTransport::MaximumHeaderSize, 'x')) << QStringLiteral("header exceeds");
+}
+
+void LanguageServerTransportTest::malformedLengths()
+{
+	QFETCH(QByteArray, input);
+	QFETCH(QString, errorFragment);
+	JsonRpcTransport transport;
+	QSignalSpy errorSpy(&transport, SIGNAL(protocolError(const QString &)));
+	transport.receiveData(input);
+	QCOMPARE(errorSpy.count(), 1);
+	QVERIFY(errorSpy.takeFirst().at(0).toString().contains(errorFragment));
+	QVERIFY(transport.isFailed());
+}
+
+void LanguageServerTransportTest::malformedAndZeroLengthJson()
+{
+	for (const QByteArray & bytes : {QByteArrayLiteral("Content-Length: 1\r\n\r\n{"), QByteArrayLiteral("Content-Length: 0\r\n\r\n")}) {
+		JsonRpcTransport transport;
+		QSignalSpy errorSpy(&transport, SIGNAL(protocolError(const QString &)));
+		transport.receiveData(bytes);
+		QCOMPARE(errorSpy.count(), 1);
+		QVERIFY(transport.isFailed());
+	}
+}
+
+void LanguageServerTransportTest::utf8Json()
+{
+	JsonRpcTransport transport;
+	QSignalSpy spy(&transport, SIGNAL(notificationReceived(const QString &, const QJsonValue &)));
+	const uint supplementaryCodePoint = 0x1F642; // U+1F642
+	const QChar highSurrogate(QChar::highSurrogate(supplementaryCodePoint));
+	const QChar lowSurrogate(QChar::lowSurrogate(supplementaryCodePoint));
+	const QString supplementaryCharacter = QString(highSurrogate) + lowSurrogate;
+	const QByteArray body = QByteArrayLiteral("{\"jsonrpc\":\"2.0\",\"method\":\"unicode\",\"params\":{\"text\":\"\xF0\x9F\x99\x82\"}}");
+	const QByteArray frame = framedBody(body);
+	QVERIFY(frame.contains(QByteArrayLiteral("\xF0\x9F\x99\x82")));
+	transport.receiveData(frame);
+	QCOMPARE(spy.count(), 1);
+	QCOMPARE(spy.takeFirst().at(1).toJsonValue().toObject().value(QStringLiteral("text")).toString(), supplementaryCharacter);
+}
+
+void LanguageServerTransportTest::failedTransportDiscardsBufferedDataAndPendingRequests()
+{
+	JsonRpcTransport transport;
+	QSignalSpy notificationSpy(&transport, SIGNAL(notificationReceived(const QString &, const QJsonValue &)));
+	QSignalSpy pendingSpy(&transport, SIGNAL(pendingRequestFailed(qint64, const QString &)));
+	transport.sendRequest(QStringLiteral("pending"));
+	transport.receiveData(QByteArrayLiteral("Content-Length: 100\r\n\r\n{"));
+	transport.fail(QStringLiteral("test failure"));
+	QCOMPARE(pendingSpy.count(), 1);
+	transport.receiveData(JsonRpcTransport::frame(notification(QStringLiteral("must/not/arrive"))));
+	QCOMPARE(notificationSpy.count(), 0);
+	QCOMPARE(transport.pendingRequestCount(), 0);
+}
+
+void LanguageServerTransportTest::notificationSerialization()
+{
+	JsonRpcTransport transport;
+	QSignalSpy outputSpy(&transport, SIGNAL(outgoingFrame(const QByteArray &)));
+	QVERIFY(transport.sendNotification(QStringLiteral("test/note"), jsonObject({{QStringLiteral("value"), 7}})));
+	const QJsonObject object = framedObject(outputSpy.takeFirst().at(0).toByteArray());
+	QCOMPARE(object.value(QStringLiteral("jsonrpc")).toString(), QStringLiteral("2.0"));
+	QCOMPARE(object.value(QStringLiteral("method")).toString(), QStringLiteral("test/note"));
+	QVERIFY(!object.contains(QStringLiteral("id")));
+	QCOMPARE(object.value(QStringLiteral("params")).toObject().value(QStringLiteral("value")).toInt(), 7);
+}
+
+void LanguageServerTransportTest::requestSerializationAndIds()
+{
+	JsonRpcTransport transport;
+	QSignalSpy outputSpy(&transport, SIGNAL(outgoingFrame(const QByteArray &)));
+	const qint64 first = transport.sendRequest(QStringLiteral("first"));
+	const qint64 second = transport.sendRequest(QStringLiteral("second"), jsonArray({1, 2}));
+	QCOMPARE(second, first + 1);
+	QCOMPARE(framedObject(outputSpy.at(0).at(0).toByteArray()).value(QStringLiteral("id")).toDouble(), static_cast<double>(first));
+	QCOMPARE(framedObject(outputSpy.at(1).at(0).toByteArray()).value(QStringLiteral("id")).toDouble(), static_cast<double>(second));
+	QVERIFY(!framedObject(outputSpy.at(0).at(0).toByteArray()).contains(QStringLiteral("params")));
+}
+
+void LanguageServerTransportTest::errorResponseSerializationNumericId()
+{
+	JsonRpcTransport transport;
+	QSignalSpy outputSpy(&transport, SIGNAL(outgoingFrame(const QByteArray &)));
+	const QJsonValue id(73);
+	QVERIFY(transport.sendErrorResponse(id, -32601, QStringLiteral("Method not found")));
+	QCOMPARE(outputSpy.count(), 1);
+	const QByteArray frame = outputSpy.takeFirst().at(0).toByteArray();
+	const QJsonObject object = framedObject(frame);
+	QVERIFY(hasByteCorrectContentLength(frame));
+	QCOMPARE(object.value(QStringLiteral("jsonrpc")).toString(), QStringLiteral("2.0"));
+	QVERIFY(object.value(QStringLiteral("id")) == id);
+	QCOMPARE(object.value(QStringLiteral("error")).toObject().value(QStringLiteral("code")).toInt(), -32601);
+	QVERIFY(!object.value(QStringLiteral("error")).toObject().value(QStringLiteral("message")).toString().isEmpty());
+	QVERIFY(!object.contains(QStringLiteral("result")));
+	QVERIFY(!object.contains(QStringLiteral("method")));
+	QVERIFY(!object.contains(QStringLiteral("params")));
+}
+
+void LanguageServerTransportTest::errorResponseSerializationStringId()
+{
+	JsonRpcTransport transport;
+	QSignalSpy outputSpy(&transport, SIGNAL(outgoingFrame(const QByteArray &)));
+	const QJsonValue id(QStringLiteral("server-request-id"));
+	QVERIFY(transport.sendErrorResponse(id, -32601, QStringLiteral("Method not found")));
+	QCOMPARE(outputSpy.count(), 1);
+	const QByteArray frame = outputSpy.takeFirst().at(0).toByteArray();
+	const QJsonObject object = framedObject(frame);
+	QVERIFY(hasByteCorrectContentLength(frame));
+	QCOMPARE(object.value(QStringLiteral("jsonrpc")).toString(), QStringLiteral("2.0"));
+	QVERIFY(object.value(QStringLiteral("id")) == id);
+	QCOMPARE(object.value(QStringLiteral("error")).toObject().value(QStringLiteral("code")).toInt(), -32601);
+	QVERIFY(!object.value(QStringLiteral("error")).toObject().value(QStringLiteral("message")).toString().isEmpty());
+	QVERIFY(!object.contains(QStringLiteral("result")));
+	QVERIFY(!object.contains(QStringLiteral("method")));
+	QVERIFY(!object.contains(QStringLiteral("params")));
+}
+
+void LanguageServerTransportTest::outgoingMessageSizeBound()
+{
+	JsonRpcTransport transport;
+	QSignalSpy outputSpy(&transport, SIGNAL(outgoingFrame(const QByteArray &)));
+	QSignalSpy errorSpy(&transport, SIGNAL(protocolError(const QString &)));
+	const QString oversized(JsonRpcTransport::MaximumMessageSize, QLatin1Char('x'));
+	QCOMPARE(transport.sendRequest(QStringLiteral("oversized"), oversized), static_cast<qint64>(-1));
+	QCOMPARE(outputSpy.count(), 0);
+	QCOMPARE(errorSpy.count(), 1);
+	QCOMPARE(transport.pendingRequestCount(), 0);
+}
+
+void LanguageServerTransportTest::successfulAndErrorCorrelation()
+{
+	JsonRpcTransport transport;
+	QSignalSpy resultSpy(&transport, SIGNAL(responseReceived(qint64, const QJsonValue &)));
+	QSignalSpy errorSpy(&transport, SIGNAL(errorResponseReceived(qint64, const QJsonObject &)));
+	const qint64 resultId = transport.sendRequest(QStringLiteral("result"));
+	const qint64 errorId = transport.sendRequest(QStringLiteral("error"));
+	transport.receiveData(JsonRpcTransport::frame(jsonObject({{QStringLiteral("jsonrpc"), QStringLiteral("2.0")}, {QStringLiteral("id"), resultId}, {QStringLiteral("result"), 42}})));
+	transport.receiveData(JsonRpcTransport::frame(jsonObject({{QStringLiteral("jsonrpc"), QStringLiteral("2.0")}, {QStringLiteral("id"), errorId}, {QStringLiteral("error"), jsonObject({{QStringLiteral("code"), -32601}, {QStringLiteral("message"), QStringLiteral("missing")}})}})));
+	QCOMPARE(resultSpy.count(), 1);
+	QCOMPARE(resultSpy.takeFirst().at(0).toLongLong(), resultId);
+	QCOMPARE(errorSpy.count(), 1);
+	QCOMPARE(errorSpy.takeFirst().at(0).toLongLong(), errorId);
+	QCOMPARE(transport.pendingRequestCount(), 0);
+}
+
+void LanguageServerTransportTest::unknownAndDuplicateResponse()
+{
+	JsonRpcTransport transport;
+	QSignalSpy unknownSpy(&transport, SIGNAL(unknownResponseReceived(const QJsonValue &)));
+	const qint64 id = transport.sendRequest(QStringLiteral("once"));
+	const QByteArray response = JsonRpcTransport::frame(jsonObject({{QStringLiteral("jsonrpc"), QStringLiteral("2.0")}, {QStringLiteral("id"), id}, {QStringLiteral("result"), true}}));
+	transport.receiveData(response);
+	transport.receiveData(response);
+	transport.receiveData(JsonRpcTransport::frame(jsonObject({{QStringLiteral("jsonrpc"), QStringLiteral("2.0")}, {QStringLiteral("id"), QStringLiteral("foreign")}, {QStringLiteral("result"), true}})));
+	QCOMPARE(unknownSpy.count(), 2);
+}
+
+void LanguageServerTransportTest::incomingNotificationAndRequest()
+{
+	JsonRpcTransport transport;
+	QSignalSpy notificationSpy(&transport, SIGNAL(notificationReceived(const QString &, const QJsonValue &)));
+	QSignalSpy requestSpy(&transport, SIGNAL(requestReceived(const QJsonValue &, const QString &, const QJsonValue &)));
+	transport.receiveData(JsonRpcTransport::frame(notification(QStringLiteral("server/note"), jsonArray({1}))));
+	transport.receiveData(JsonRpcTransport::frame(jsonObject({{QStringLiteral("jsonrpc"), QStringLiteral("2.0")}, {QStringLiteral("id"), QStringLiteral("server-id")}, {QStringLiteral("method"), QStringLiteral("server/request")}})));
+	QCOMPARE(notificationSpy.count(), 1);
+	QCOMPARE(requestSpy.count(), 1);
+	QCOMPARE(requestSpy.takeFirst().at(0).toJsonValue().toString(), QStringLiteral("server-id"));
+}
+
+void LanguageServerTransportTest::invalidJsonRpcMarker()
+{
+	for (const QJsonObject & message : {
+		jsonObject({{QStringLiteral("method"), QStringLiteral("missing")}}),
+		jsonObject({{QStringLiteral("jsonrpc"), QStringLiteral("1.0")}, {QStringLiteral("method"), QStringLiteral("old")}})
+	}) {
+		JsonRpcTransport transport;
+		QSignalSpy errorSpy(&transport, SIGNAL(protocolError(const QString &)));
+		transport.receiveData(JsonRpcTransport::frame(message));
+		QCOMPARE(errorSpy.count(), 1);
+	}
+}
+
+void LanguageServerTransportTest::processRoundTripAndFragmentation()
+{
+	LanguageServerProcess process;
+	QSignalSpy responseSpy(process.transport(), SIGNAL(responseReceived(qint64, const QJsonValue &)));
+	QVERIFY(process.start(fakeServerPath()));
+	waitForRunning(process);
+	process.transport()->sendRequest(QStringLiteral("echo"), jsonObject({{QStringLiteral("text"), QStringLiteral("stdin reached server")}}));
+	QTRY_COMPARE(responseSpy.count(), 1);
+	process.transport()->sendRequest(QStringLiteral("fragmentHeader"), jsonObject({{QStringLiteral("part"), QStringLiteral("header")}}));
+	QTRY_COMPARE(responseSpy.count(), 2);
+	process.transport()->sendRequest(QStringLiteral("fragmentBody"), jsonObject({{QStringLiteral("part"), QStringLiteral("body")}}));
+	QTRY_COMPARE(responseSpy.count(), 3);
+	process.stop(200, 200);
+	QTRY_COMPARE(process.state(), LanguageServerProcess::NotRunning);
+}
+
+void LanguageServerTransportTest::processCoalescedFramesAndStderrIsolation()
+{
+	LanguageServerProcess process;
+	QSignalSpy responseSpy(process.transport(), SIGNAL(responseReceived(qint64, const QJsonValue &)));
+	QSignalSpy notificationSpy(process.transport(), SIGNAL(notificationReceived(const QString &, const QJsonValue &)));
+	QSignalSpy stderrSpy(&process, SIGNAL(standardErrorReceived(const QByteArray &)));
+	QSignalSpy protocolErrorSpy(process.transport(), SIGNAL(protocolError(const QString &)));
+	QVERIFY(process.start(fakeServerPath()));
+	waitForRunning(process);
+	process.transport()->sendRequest(QStringLiteral("several"), jsonObject({{QStringLiteral("test"), true}}));
+	QTRY_COMPARE(responseSpy.count(), 1);
+	QCOMPARE(notificationSpy.count(), 1);
+	process.transport()->sendRequest(QStringLiteral("stderr"), jsonObject({{QStringLiteral("test"), true}}));
+	QTRY_COMPARE(responseSpy.count(), 2);
+	QTRY_VERIFY(!stderrSpy.isEmpty());
+	QVERIFY(stderrSpy.at(0).at(0).toByteArray().contains("fake-server stderr"));
+	QCOMPARE(protocolErrorSpy.count(), 0);
+	process.stop(200, 200);
+	QTRY_COMPARE(process.state(), LanguageServerProcess::NotRunning);
+}
+
+void LanguageServerTransportTest::processDelayKeepsEventLoopResponsive()
+{
+	LanguageServerProcess process;
+	QSignalSpy responseSpy(process.transport(), SIGNAL(responseReceived(qint64, const QJsonValue &)));
+	QVERIFY(process.start(fakeServerPath()));
+	waitForRunning(process);
+	m_timerFired = false;
+	process.transport()->sendRequest(QStringLiteral("delay"), jsonObject({{QStringLiteral("delayed"), true}}));
+	QTimer::singleShot(0, this, SLOT(markTimerFired()));
+	QTRY_VERIFY(m_timerFired);
+	QCOMPARE(responseSpy.count(), 0);
+	QTRY_COMPARE(responseSpy.count(), 1);
+	process.stop(200, 200);
+	QTRY_COMPARE(process.state(), LanguageServerProcess::NotRunning);
+}
+
+void LanguageServerTransportTest::processProtocolFailureStopsProcess()
+{
+	LanguageServerProcess process;
+	QSignalSpy protocolErrorSpy(process.transport(), SIGNAL(protocolError(const QString &)));
+	QSignalSpy pendingSpy(process.transport(), SIGNAL(pendingRequestFailed(qint64, const QString &)));
+	QSignalSpy finishedSpy(&process, SIGNAL(processFinished(int, QProcess::ExitStatus, bool)));
+	QVERIFY(process.start(fakeServerPath()));
+	waitForRunning(process);
+	process.transport()->sendRequest(QStringLiteral("malformed"), jsonObject({{QStringLiteral("test"), true}}));
+	QTRY_COMPARE(protocolErrorSpy.count(), 1);
+	QCOMPARE(pendingSpy.count(), 1);
+	QTRY_COMPARE(finishedSpy.count(), 1);
+	QCOMPARE(process.state(), LanguageServerProcess::Failed);
+}
+
+void LanguageServerTransportTest::processNormalAndUnexpectedExit()
+{
+	{
+		LanguageServerProcess process;
+		QSignalSpy finishedSpy(&process, SIGNAL(processFinished(int, QProcess::ExitStatus, bool)));
+		QVERIFY(process.start(fakeServerPath()));
+		waitForRunning(process);
+		process.stop(200, 200);
+	QTRY_COMPARE(finishedSpy.count(), 1);
+		QCOMPARE(finishedSpy.at(0).at(1).toInt(), static_cast<int>(QProcess::NormalExit));
+		QCOMPARE(finishedSpy.at(0).at(2).toBool(), false);
+	}
+	{
+		LanguageServerProcess process;
+		QSignalSpy finishedSpy(&process, SIGNAL(processFinished(int, QProcess::ExitStatus, bool)));
+		QSignalSpy pendingSpy(process.transport(), SIGNAL(pendingRequestFailed(qint64, const QString &)));
+		QVERIFY(process.start(fakeServerPath()));
+		waitForRunning(process);
+		process.transport()->sendRequest(QStringLiteral("exitNormal"), jsonObject({{QStringLiteral("pending"), true}}));
+		QTRY_COMPARE(finishedSpy.count(), 1);
+		QCOMPARE(finishedSpy.at(0).at(1).toInt(), static_cast<int>(QProcess::NormalExit));
+		QCOMPARE(finishedSpy.at(0).at(2).toBool(), true);
+		QCOMPARE(pendingSpy.count(), 1);
+		QCOMPARE(process.state(), LanguageServerProcess::Failed);
+	}
+	{
+		LanguageServerProcess process;
+		QSignalSpy finishedSpy(&process, SIGNAL(processFinished(int, QProcess::ExitStatus, bool)));
+		QVERIFY(process.start(fakeServerPath(), {QStringLiteral("--crash")}));
+		QTRY_COMPARE(finishedSpy.count(), 1);
+		QCOMPARE(finishedSpy.at(0).at(1).toInt(), static_cast<int>(QProcess::CrashExit));
+		QCOMPARE(finishedSpy.at(0).at(2).toBool(), true);
+	}
+}
+
+void LanguageServerTransportTest::processStartFailure()
+{
+	LanguageServerProcess process;
+	QSignalSpy errorSpy(&process, SIGNAL(processError(QProcess::ProcessError, const QString &)));
+	QVERIFY(process.start(QDir(QCoreApplication::applicationDirPath()).filePath(QStringLiteral("missing-language-server-executable"))));
+	QTRY_COMPARE(errorSpy.count(), 1);
+	QCOMPARE(errorSpy.at(0).at(0).toInt(), static_cast<int>(QProcess::FailedToStart));
+	QCOMPARE(process.state(), LanguageServerProcess::Failed);
+}
+
+void LanguageServerTransportTest::processStopIsBounded()
+{
+	LanguageServerProcess process;
+	QSignalSpy finishedSpy(&process, SIGNAL(processFinished(int, QProcess::ExitStatus, bool)));
+	QVERIFY(process.start(fakeServerPath(), {QStringLiteral("--idle")}));
+	waitForRunning(process);
+	QElapsedTimer elapsed;
+	elapsed.start();
+	process.stop(20, 20);
+	QTRY_COMPARE(finishedSpy.count(), 1);
+	QVERIFY(elapsed.elapsed() < 1000);
+	QCOMPARE(finishedSpy.at(0).at(2).toBool(), false);
+	QCOMPARE(process.state(), LanguageServerProcess::NotRunning);
+}
+
+void LanguageServerTransportTest::processDestructionDoesNotHang()
+{
+	LanguageServerProcess * process = new LanguageServerProcess;
+	QVERIFY(process->start(fakeServerPath(), {QStringLiteral("--idle")}));
+	waitForRunning(*process);
+	QElapsedTimer elapsed;
+	elapsed.start();
+	delete process;
+	QVERIFY(elapsed.elapsed() < 1000);
+}
+
+QTEST_GUILESS_MAIN(LanguageServerTransportTest)

--- a/unit-tests/LanguageServerTransport_test.h
+++ b/unit-tests/LanguageServerTransport_test.h
@@ -1,0 +1,70 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+	For links to further information, or to contact the authors,
+	see <https://tug.org/texworks/>.
+*/
+#ifndef LANGUAGESERVERTRANSPORT_TEST_H
+#define LANGUAGESERVERTRANSPORT_TEST_H
+
+#include <QObject>
+
+class LanguageServerTransportTest : public QObject
+{
+	Q_OBJECT
+
+public slots:
+	void markTimerFired();
+
+private slots:
+	void initTestCase();
+
+	void completeFrame();
+	void fragmentedHeader();
+	void fragmentedBody();
+	void severalFramesAndTrailingPartial();
+	void caseInsensitiveAndAdditionalHeader();
+	void malformedLengths_data();
+	void malformedLengths();
+	void malformedAndZeroLengthJson();
+	void utf8Json();
+	void failedTransportDiscardsBufferedDataAndPendingRequests();
+
+	void notificationSerialization();
+	void requestSerializationAndIds();
+	void errorResponseSerializationNumericId();
+	void errorResponseSerializationStringId();
+	void outgoingMessageSizeBound();
+	void successfulAndErrorCorrelation();
+	void unknownAndDuplicateResponse();
+	void incomingNotificationAndRequest();
+	void invalidJsonRpcMarker();
+
+	void processRoundTripAndFragmentation();
+	void processCoalescedFramesAndStderrIsolation();
+	void processDelayKeepsEventLoopResponsive();
+	void processProtocolFailureStopsProcess();
+	void processNormalAndUnexpectedExit();
+	void processStartFailure();
+	void processStopIsBounded();
+	void processDestructionDoesNotHang();
+
+private:
+	bool m_timerFired{false};
+};
+
+#endif // LANGUAGESERVERTRANSPORT_TEST_H

--- a/unit-tests/LanguageServiceDocument_test.cpp
+++ b/unit-tests/LanguageServiceDocument_test.cpp
@@ -1,0 +1,898 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+
+#include "LanguageServiceDocument_test.h"
+
+#include "document/TeXDocument.h"
+#include "languageservices/LanguageServiceDocumentBinding.h"
+#include "languageservices/LanguageServiceManager.h"
+#include "languageservices/LanguageServiceNavigation.h"
+
+#include <QDir>
+#include <QFile>
+#include <QPointer>
+#include <QTemporaryDir>
+#include <QTextCursor>
+#include <QtTest>
+
+using namespace Tw::LanguageServices;
+
+namespace {
+
+struct Operation {
+	enum Kind { Open, Change, Close, Completion, Definition } kind;
+	QUrl url;
+	QString languageId;
+	quint64 version{0};
+	QString text;
+	bool hasRange{false};
+	LanguageRange range;
+	LanguageDefinitionRequest definitionRequest;
+	LanguageCompletionRequest completionRequest;
+};
+
+class RecordingService : public LanguageService
+{
+public:
+	explicit RecordingService(const LanguageServiceCapabilities & capabilities)
+		: m_configuredCapabilities(capabilities) { }
+
+	bool start() override
+	{
+		if (!beginStart())
+			return false;
+		setState(Initializing);
+		becomeReady(m_configuredCapabilities);
+		return true;
+	}
+	void stop() override
+	{
+		if (state() == Stopped)
+			return;
+		setState(Stopping);
+		if (!holdStop)
+			becomeStopped();
+	}
+	void finishStop() { becomeStopped(); }
+	bool openDocument(const LanguageDocumentOpen & document) override
+	{
+		Operation operation;
+		operation.kind = Operation::Open;
+		operation.url = document.url;
+		operation.languageId = document.languageId;
+		operation.version = document.version;
+		operation.text = document.text;
+		operations.append(operation);
+		return true;
+	}
+	bool changeDocument(const QUrl & url, quint64 version, const LanguageDocumentChange & change) override
+	{
+		Operation operation;
+		operation.kind = Operation::Change;
+		operation.url = url;
+		operation.version = version;
+		operation.text = change.text;
+		operation.hasRange = change.hasRange;
+		operation.range = change.range;
+		operations.append(operation);
+		return true;
+	}
+	bool closeDocument(const QUrl & url) override
+	{
+		Operation operation;
+		operation.kind = Operation::Close;
+		operation.url = url;
+		operations.append(operation);
+		return true;
+	}
+	bool requestCompletion(const LanguageCompletionRequest & request) override
+	{
+		Operation operation;
+		operation.kind = Operation::Completion;
+		operation.completionRequest = request;
+		operations.append(operation);
+		return acceptCompletionRequests;
+	}
+	bool requestDefinition(const LanguageDefinitionRequest & request) override
+	{
+		Operation operation;
+		operation.kind = Operation::Definition;
+		operation.definitionRequest = request;
+		operations.append(operation);
+		return acceptDefinitionRequests;
+	}
+	void finishDefinition(quint64 token, const QList<LanguageLocation> & locations)
+	{
+		emit definitionFinished(token, locations);
+	}
+	void finishCompletion(quint64 token, const QList<CompletionItem> & items)
+	{
+		emit completionFinished(token, items);
+	}
+	void failCompletionRequest(quint64 token)
+	{
+		emit completionFailed(token, QStringLiteral("scripted completion failure"));
+	}
+	void fail() { becomeFailed(QStringLiteral("scripted failure")); }
+
+	QList<Operation> operations;
+	bool acceptDefinitionRequests{true};
+	bool acceptCompletionRequests{true};
+	bool holdStop{false};
+
+private:
+	LanguageServiceCapabilities m_configuredCapabilities;
+};
+
+QString createFile(QTemporaryDir & directory, const QString & name)
+{
+	const QString path = QDir(directory.path()).filePath(name);
+	QFile file(path);
+	if (!file.open(QIODevice::WriteOnly))
+		return {};
+	file.close();
+	return path;
+}
+
+void store(Tw::Document::TeXDocument & document, const QString & path)
+{
+	document.documentLayout();
+	document.setFileInfo(QFileInfo(path));
+	document.setStoredInFilesystem(true);
+}
+
+LanguageServiceCapabilities capabilities(TextSyncKind sync = TextSyncKind::Incremental, bool openClose = true,
+	                                     bool definition = false, bool completion = false)
+{
+	LanguageServiceCapabilities result;
+	result.textSync = sync;
+	result.openClose = openClose;
+	result.definition = definition;
+	result.completion = completion;
+	return result;
+}
+
+RecordingService * configure(LanguageServiceManager & manager, const LanguageServiceCapabilities & caps)
+{
+	RecordingService * service = new RecordingService(caps);
+	const bool configured = manager.setService(service, QStringList{QStringLiteral("context")});
+	const bool started = configured && manager.start();
+	Q_ASSERT(configured);
+	Q_ASSERT(started);
+	return service;
+}
+
+void comparePosition(const LanguagePosition & actual, int line, int character)
+{
+	QCOMPARE(actual.line, line);
+	QCOMPARE(actual.character, character);
+}
+
+LanguagePosition languagePosition(int line, int character)
+{
+	LanguagePosition position;
+	position.line = line;
+	position.character = character;
+	return position;
+}
+
+} // namespace
+
+void LanguageServiceDocumentTest::eligibility()
+{
+	QTemporaryDir directory;
+	QVERIFY(directory.isValid());
+	Tw::Document::TeXDocument document;
+	QVERIFY(!LanguageServiceManager::isSourceEligible(&document));
+	QCOMPARE(LanguageServiceManager::identifyLanguageId(&document), QString());
+
+	store(document, createFile(directory, QStringLiteral("a.mkxl")));
+	QVERIFY(LanguageServiceManager::isSourceEligible(&document));
+	QCOMPARE(LanguageServiceManager::identifyLanguageId(&document), QStringLiteral("context"));
+	store(document, createFile(directory, QStringLiteral("a.mkiv")));
+	QCOMPARE(LanguageServiceManager::identifyLanguageId(&document), QStringLiteral("context"));
+	store(document, createFile(directory, QStringLiteral("a.tex")));
+	QCOMPARE(LanguageServiceManager::identifyLanguageId(&document), QString());
+	QCOMPARE(LanguageServiceManager::identifyLanguageId(&document, QStringLiteral("context")), QStringLiteral("context"));
+	QCOMPARE(LanguageServiceManager::identifyLanguageId(&document, QStringLiteral("ConTeXt (LuaMetaTeX)")), QString());
+	document.setPlainText(QStringLiteral("%!TEX program = context\nbody"));
+	QCOMPARE(LanguageServiceManager::identifyLanguageId(&document), QStringLiteral("context"));
+	document.setPlainText(QStringLiteral("%!TEX program = pdfLaTeX\nbody"));
+	QCOMPARE(LanguageServiceManager::identifyLanguageId(&document, QStringLiteral("context")), QString());
+	store(document, createFile(directory, QStringLiteral("a.txt")));
+	QCOMPARE(LanguageServiceManager::identifyLanguageId(&document, QStringLiteral("context")), QString());
+}
+
+void LanguageServiceDocumentTest::texIntentChanges()
+{
+	QTemporaryDir directory;
+	LanguageServiceManager manager;
+	RecordingService * service = configure(manager, capabilities());
+	Tw::Document::TeXDocument document(QStringLiteral("%!TEX program = pdfLaTeX\nbody"));
+	store(document, createFile(directory, QStringLiteral("a.tex")));
+	manager.registerDocument(&document, QStringLiteral("context"));
+	QVERIFY(service->operations.isEmpty());
+	document.setPlainText(QStringLiteral("%!TEX program = context\nbody"));
+	QCOMPARE(service->operations.size(), 0);
+	QTRY_COMPARE(service->operations.size(), 1);
+	QCOMPARE(service->operations.last().kind, Operation::Open);
+	document.setPlainText(QStringLiteral("%!TEX program = pdfLaTeX\nbody"));
+	const auto operationsBeforeDeferredClose = service->operations.size();
+	QVERIFY(operationsBeforeDeferredClose > 1);
+	QCOMPARE(service->operations.last().kind, Operation::Change);
+	QTRY_COMPARE(service->operations.size(), operationsBeforeDeferredClose + 1);
+	QCOMPARE(service->operations.last().kind, Operation::Close);
+}
+
+void LanguageServiceDocumentTest::deferredRefreshIsolation()
+{
+	QTemporaryDir directory;
+	LanguageServiceManager manager;
+	RecordingService * service = configure(manager, capabilities());
+	Tw::Document::TeXDocument first(QStringLiteral("%!TEX program = pdfLaTeX\nbody"));
+	Tw::Document::TeXDocument second(QStringLiteral("%!TEX program = pdfLaTeX\nbody"));
+	store(first, createFile(directory, QStringLiteral("first.tex")));
+	store(second, createFile(directory, QStringLiteral("second.tex")));
+	manager.registerDocument(&first, QStringLiteral("context"));
+	manager.registerDocument(&second, QStringLiteral("context"));
+
+	first.setPlainText(QStringLiteral("%!TEX program = context\n%!TEX encoding = UTF-8\nbody"));
+	QCOMPARE(service->operations.size(), 0);
+	first.setPlainText(QStringLiteral("%!TEX program = context\nbody"));
+	QCOMPARE(service->operations.size(), 0);
+	QTRY_COMPARE(service->operations.size(), 1);
+	QCOMPARE(service->operations.first().kind, Operation::Open);
+	QCOMPARE(service->operations.first().url, manager.bindingForDocument(&first)->url());
+	QVERIFY(manager.bindingForDocument(&second)->languageId().isEmpty());
+
+	second.setPlainText(QStringLiteral("%!TEX program = context\nbody"));
+	QCOMPARE(service->operations.size(), 1);
+	QTRY_COMPARE(service->operations.size(), 2);
+	QCOMPARE(service->operations.last().kind, Operation::Open);
+	QCOMPARE(service->operations.last().url, manager.bindingForDocument(&second)->url());
+}
+
+void LanguageServiceDocumentTest::deferredRefreshLifecycle()
+{
+	QTemporaryDir directory;
+	LanguageServiceManager manager;
+	RecordingService * service = configure(manager, capabilities());
+
+	Tw::Document::TeXDocument removed(QStringLiteral("%!TEX program = pdfLaTeX\nbody"));
+	store(removed, createFile(directory, QStringLiteral("removed.tex")));
+	manager.registerDocument(&removed, QStringLiteral("context"));
+	removed.setPlainText(QStringLiteral("%!TEX program = context\nbody"));
+	QCOMPARE(service->operations.size(), 0);
+	manager.unregisterDocument(&removed);
+
+	Tw::Document::TeXDocument survivor(QStringLiteral("%!TEX program = pdfLaTeX\nbody"));
+	store(survivor, createFile(directory, QStringLiteral("survivor.tex")));
+	manager.registerDocument(&survivor, QStringLiteral("context"));
+	survivor.setPlainText(QStringLiteral("%!TEX program = context\nbody"));
+	QCOMPARE(service->operations.size(), 0);
+	QTRY_COMPARE(service->operations.size(), 1);
+	QCOMPARE(service->operations.first().url, manager.bindingForDocument(&survivor)->url());
+
+	Tw::Document::TeXDocument * destroyed = new Tw::Document::TeXDocument(
+	    QStringLiteral("%!TEX program = pdfLaTeX\nbody"));
+	const QPointer<Tw::Document::TeXDocument> destroyedGuard(destroyed);
+	store(*destroyed, createFile(directory, QStringLiteral("destroyed.tex")));
+	manager.registerDocument(destroyed, QStringLiteral("context"));
+	destroyed->setPlainText(QStringLiteral("%!TEX program = context\nbody"));
+	QCOMPARE(service->operations.size(), 1);
+	delete destroyed;
+	QVERIFY(destroyedGuard.isNull());
+
+	Tw::Document::TeXDocument trigger(QStringLiteral("%!TEX program = pdfLaTeX\nbody"));
+	store(trigger, createFile(directory, QStringLiteral("trigger.tex")));
+	manager.registerDocument(&trigger, QStringLiteral("context"));
+	trigger.setPlainText(QStringLiteral("%!TEX program = context\nbody"));
+	QCOMPARE(service->operations.size(), 1);
+	QTRY_COMPARE(service->operations.size(), 2);
+	QCOMPARE(service->operations.last().url, manager.bindingForDocument(&trigger)->url());
+
+	Tw::Document::TeXDocument managerDocument(QStringLiteral("%!TEX program = pdfLaTeX\nbody"));
+	store(managerDocument, createFile(directory, QStringLiteral("manager.tex")));
+	LanguageServiceManager * destroyedManager = new LanguageServiceManager;
+	RecordingService * destroyedService = configure(*destroyedManager, capabilities());
+	destroyedManager->registerDocument(&managerDocument, QStringLiteral("context"));
+	managerDocument.setPlainText(QStringLiteral("%!TEX program = context\nbody"));
+	QCOMPARE(destroyedService->operations.size(), 0);
+	delete destroyedManager;
+
+	Tw::Document::TeXDocument finalTrigger(QStringLiteral("%!TEX program = pdfLaTeX\nbody"));
+	store(finalTrigger, createFile(directory, QStringLiteral("final-trigger.tex")));
+	manager.registerDocument(&finalTrigger, QStringLiteral("context"));
+	finalTrigger.setPlainText(QStringLiteral("%!TEX program = context\nbody"));
+	QCOMPARE(service->operations.size(), 2);
+	QTRY_COMPARE(service->operations.size(), 3);
+	QCOMPARE(service->operations.last().url, manager.bindingForDocument(&finalTrigger)->url());
+}
+
+void LanguageServiceDocumentTest::unsavedThenStored()
+{
+	QTemporaryDir directory;
+	LanguageServiceManager manager;
+	RecordingService * service = configure(manager, capabilities());
+	Tw::Document::TeXDocument document(QStringLiteral("alpha\n"));
+	manager.registerDocument(&document);
+	QVERIFY(service->operations.isEmpty());
+	store(document, createFile(directory, QStringLiteral("a.mkxl")));
+	manager.updateDocumentIdentity(&document);
+	QCOMPARE(service->operations.size(), 1);
+	QCOMPARE(service->operations.first().kind, Operation::Open);
+	QCOMPARE(service->operations.first().languageId, QStringLiteral("context"));
+	QCOMPARE(service->operations.first().version, quint64(1));
+	QCOMPARE(service->operations.first().text, document.canonicalText());
+}
+
+void LanguageServiceDocumentTest::openCloseCapability()
+{
+	QTemporaryDir directory;
+	LanguageServiceManager manager;
+	RecordingService * service = configure(manager, capabilities(TextSyncKind::Incremental, false));
+	Tw::Document::TeXDocument document(QStringLiteral("abc"));
+	store(document, createFile(directory, QStringLiteral("a.mkiv")));
+	manager.registerDocument(&document);
+	QVERIFY(service->operations.isEmpty());
+	QTextCursor cursor(&document);
+	cursor.insertText(QStringLiteral("x"));
+	QCOMPARE(service->operations.size(), 1);
+	QCOMPARE(service->operations.first().kind, Operation::Change);
+	manager.unregisterDocument(&document);
+	QCOMPARE(service->operations.size(), 1);
+}
+
+void LanguageServiceDocumentTest::syncNone()
+{
+	QTemporaryDir directory;
+	LanguageServiceManager manager;
+	RecordingService * service = configure(manager, capabilities(TextSyncKind::None));
+	Tw::Document::TeXDocument document(QStringLiteral("abc"));
+	store(document, createFile(directory, QStringLiteral("a.mkxl")));
+	manager.registerDocument(&document);
+	QTextCursor(&document).insertText(QStringLiteral("x"));
+	QCOMPARE(service->operations.size(), 1);
+	QCOMPARE(service->operations.first().kind, Operation::Open);
+}
+
+void LanguageServiceDocumentTest::fullSynchronization()
+{
+	QTemporaryDir directory;
+	LanguageServiceManager manager;
+	RecordingService * service = configure(manager, capabilities(TextSyncKind::Full));
+	Tw::Document::TeXDocument document(QStringLiteral("abc"));
+	store(document, createFile(directory, QStringLiteral("a.mkxl")));
+	manager.registerDocument(&document);
+	QTextCursor cursor(&document);
+	cursor.movePosition(QTextCursor::End);
+	cursor.insertText(QStringLiteral("\né"));
+	QCOMPARE(service->operations.size(), 2);
+	const Operation change = service->operations.last();
+	QCOMPARE(change.kind, Operation::Change);
+	QCOMPARE(change.version, quint64(2));
+	QVERIFY(!change.hasRange);
+	QCOMPARE(change.text, document.canonicalText());
+}
+
+void LanguageServiceDocumentTest::incrementalChanges_data()
+{
+	QTest::addColumn<QString>("initial");
+	QTest::addColumn<int>("position");
+	QTest::addColumn<int>("removed");
+	QTest::addColumn<QString>("inserted");
+	QTest::addColumn<int>("startLine");
+	QTest::addColumn<int>("startCharacter");
+	QTest::addColumn<int>("endLine");
+	QTest::addColumn<int>("endCharacter");
+	QTest::newRow("ASCII") << QStringLiteral("abc") << 1 << 1 << QStringLiteral("X") << 0 << 1 << 0 << 2;
+	QTest::newRow("BMP") << QString::fromUtf8("aébc") << 1 << 1 << QStringLiteral("X") << 0 << 1 << 0 << 2;
+	QTest::newRow("supplementary before") << QString::fromUtf8("😀abc") << 3 << 1 << QStringLiteral("X") << 0 << 3 << 0 << 4;
+	QTest::newRow("supplementary removed") << QString::fromUtf8("a😀b") << 1 << 2 << QStringLiteral("X") << 0 << 1 << 0 << 3;
+	QTest::newRow("multiline insert") << QStringLiteral("ab\ncd") << 3 << 0 << QStringLiteral("X\nY") << 1 << 0 << 1 << 0;
+	QTest::newRow("multiline replace") << QStringLiteral("ab\ncd\nef") << 1 << 6 << QStringLiteral("Z") << 0 << 1 << 2 << 1;
+}
+
+void LanguageServiceDocumentTest::incrementalChanges()
+{
+	QFETCH(QString, initial);
+	QFETCH(int, position);
+	QFETCH(int, removed);
+	QFETCH(QString, inserted);
+	QFETCH(int, startLine);
+	QFETCH(int, startCharacter);
+	QFETCH(int, endLine);
+	QFETCH(int, endCharacter);
+	QTemporaryDir directory;
+	LanguageServiceManager manager;
+	RecordingService * service = configure(manager, capabilities());
+	Tw::Document::TeXDocument document(initial);
+	store(document, createFile(directory, QStringLiteral("a.mkxl")));
+	manager.registerDocument(&document);
+	QTextCursor cursor(&document);
+	cursor.setPosition(position);
+	cursor.setPosition(position + removed, QTextCursor::KeepAnchor);
+	cursor.insertText(inserted);
+	QCOMPARE(service->operations.size(), 2);
+	const Operation change = service->operations.last();
+	QVERIFY(change.hasRange);
+	comparePosition(change.range.start, startLine, startCharacter);
+	comparePosition(change.range.end, endLine, endCharacter);
+	QCOMPARE(change.text, inserted);
+	QCOMPARE(change.version, quint64(2));
+	LanguageServiceDocumentBinding * binding = manager.bindingForDocument(&document);
+	QVERIFY(binding);
+	QCOMPARE(binding->shadow(), document.canonicalText());
+}
+
+void LanguageServiceDocumentTest::undoRedo()
+{
+	QTemporaryDir directory;
+	LanguageServiceManager manager;
+	RecordingService * service = configure(manager, capabilities());
+	Tw::Document::TeXDocument document(QStringLiteral("abc"));
+	document.setUndoRedoEnabled(true);
+	store(document, createFile(directory, QStringLiteral("a.mkxl")));
+	manager.registerDocument(&document);
+	QTextCursor cursor(&document);
+	cursor.movePosition(QTextCursor::End);
+	cursor.insertText(QStringLiteral("x"));
+	document.undo();
+	document.redo();
+	QCOMPARE(service->operations.size(), 4);
+	QCOMPARE(service->operations.at(1).version, quint64(2));
+	QCOMPARE(service->operations.at(2).version, quint64(3));
+	QCOMPARE(service->operations.at(3).version, quint64(4));
+	QCOMPARE(manager.bindingForDocument(&document)->shadow(), document.canonicalText());
+}
+
+void LanguageServiceDocumentTest::sameIdentityIsSilent()
+{
+	QTemporaryDir directory;
+	LanguageServiceManager manager;
+	RecordingService * service = configure(manager, capabilities());
+	Tw::Document::TeXDocument document(QStringLiteral("abc"));
+	store(document, createFile(directory, QStringLiteral("a.mkxl")));
+	manager.registerDocument(&document);
+	manager.updateDocumentIdentity(&document);
+	QCOMPARE(service->operations.size(), 1);
+}
+
+void LanguageServiceDocumentTest::identityAndEligibilityTransitions()
+{
+	QTemporaryDir directory;
+	LanguageServiceManager manager;
+	RecordingService * service = configure(manager, capabilities());
+	Tw::Document::TeXDocument document(QStringLiteral("abc"));
+	const QString first = createFile(directory, QStringLiteral("a.mkxl"));
+	const QString second = createFile(directory, QStringLiteral("b.mkiv"));
+	store(document, first);
+	manager.registerDocument(&document);
+	store(document, second);
+	manager.updateDocumentIdentity(&document);
+	QCOMPARE(service->operations.size(), 3);
+	QCOMPARE(service->operations.at(1).kind, Operation::Close);
+	QCOMPARE(service->operations.at(1).url, QUrl::fromLocalFile(QFileInfo(first).canonicalFilePath()));
+	QCOMPARE(service->operations.at(2).kind, Operation::Open);
+	QCOMPARE(service->operations.at(2).version, quint64(1));
+
+	store(document, createFile(directory, QStringLiteral("c.txt")));
+	manager.updateDocumentIdentity(&document);
+	QCOMPARE(service->operations.last().kind, Operation::Close);
+	const auto afterClose = service->operations.size();
+	QTextCursor(&document).insertText(QStringLiteral("x"));
+	QCOMPARE(service->operations.size(), afterClose);
+
+	store(document, createFile(directory, QStringLiteral("d.mkxl")));
+	manager.updateDocumentIdentity(&document);
+	QCOMPARE(service->operations.last().kind, Operation::Open);
+	QCOMPARE(service->operations.last().version, quint64(1));
+}
+
+void LanguageServiceDocumentTest::reloadSynchronizes()
+{
+	QTemporaryDir directory;
+	LanguageServiceManager manager;
+	RecordingService * service = configure(manager, capabilities());
+	Tw::Document::TeXDocument document(QStringLiteral("old\ntext"));
+	store(document, createFile(directory, QStringLiteral("a.mkxl")));
+	manager.registerDocument(&document);
+	document.setPlainText(QString::fromUtf8("new 😀\ntext\nmore"));
+	QVERIFY(service->operations.size() >= 2);
+	QCOMPARE(manager.bindingForDocument(&document)->shadow(), document.canonicalText());
+	QCOMPARE(service->operations.last().version, manager.bindingForDocument(&document)->version());
+}
+
+void LanguageServiceDocumentTest::serviceLifecycleAndGeneration()
+{
+	QTemporaryDir directory;
+	LanguageServiceManager manager;
+	RecordingService * service = configure(manager, capabilities());
+	Tw::Document::TeXDocument document(QStringLiteral("abc"));
+	store(document, createFile(directory, QStringLiteral("a.mkxl")));
+	manager.registerDocument(&document);
+	const quint64 firstGeneration = manager.bindingForDocument(&document)->serviceGeneration();
+	service->fail();
+	QVERIFY(!manager.bindingForDocument(&document)->isSynchronized());
+	QTextCursor(&document).insertText(QStringLiteral("x"));
+	QCOMPARE(service->operations.size(), 1);
+	service->stop();
+	QVERIFY(service->start());
+	QVERIFY(manager.bindingForDocument(&document)->isSynchronized());
+	QVERIFY(manager.bindingForDocument(&document)->serviceGeneration() != firstGeneration);
+	QCOMPARE(service->operations.last().kind, Operation::Open);
+	QCOMPARE(service->operations.last().text, document.canonicalText());
+	manager.stop();
+	QCOMPARE(service->operations.last().kind, Operation::Close);
+	QCOMPARE(service->state(), LanguageService::Stopped);
+}
+
+void LanguageServiceDocumentTest::replacementKeepsDocumentBinding()
+{
+	QTemporaryDir directory;
+	QVERIFY(directory.isValid());
+	LanguageServiceManager manager;
+	RecordingService * active = configure(manager, capabilities());
+	Tw::Document::TeXDocument document(QStringLiteral("abc"));
+	store(document, createFile(directory, QStringLiteral("replacement.mkxl")));
+	manager.registerDocument(&document);
+	const quint64 activeGeneration = manager.bindingForDocument(&document)->serviceGeneration();
+	active->holdStop = true;
+
+	RecordingService * pending = new RecordingService(capabilities());
+	QVERIFY(manager.replaceService(pending, QStringList{QStringLiteral("context")}));
+	QVERIFY(manager.bindingForDocument(&document) == nullptr);
+	active->finishStop();
+	QCOMPARE(manager.service(), static_cast<LanguageService *>(pending));
+	QCOMPARE(manager.bindingForDocument(&document)->serviceGeneration(), pending->generation());
+	QVERIFY(pending->generation() != activeGeneration);
+}
+
+void LanguageServiceDocumentTest::closeLifecycle()
+{
+	QTemporaryDir directory;
+	LanguageServiceManager manager;
+	RecordingService * service = configure(manager, capabilities());
+	Tw::Document::TeXDocument document(QStringLiteral("abc"));
+	store(document, createFile(directory, QStringLiteral("a.mkxl")));
+	manager.registerDocument(&document);
+	manager.unregisterDocument(&document);
+	QCOMPARE(service->operations.last().kind, Operation::Close);
+	QVERIFY(manager.bindingForDocument(&document) == nullptr);
+
+	LanguageServiceManager failedManager;
+	RecordingService * failed = configure(failedManager, capabilities());
+	Tw::Document::TeXDocument second(QStringLiteral("abc"));
+	store(second, createFile(directory, QStringLiteral("b.mkxl")));
+	failedManager.registerDocument(&second);
+	failed->fail();
+	failedManager.unregisterDocument(&second);
+	QCOMPARE(failed->operations.size(), 1);
+}
+
+void LanguageServiceDocumentTest::multipleDocumentsShareService()
+{
+	QTemporaryDir directory;
+	LanguageServiceManager manager;
+	RecordingService * service = configure(manager, capabilities());
+	Tw::Document::TeXDocument first(QStringLiteral("one"));
+	Tw::Document::TeXDocument second(QStringLiteral("two"));
+	store(first, createFile(directory, QStringLiteral("a.mkxl")));
+	store(second, createFile(directory, QStringLiteral("b.mkxl")));
+	manager.registerDocument(&first);
+	manager.registerDocument(&second);
+	QCOMPARE(manager.service(), service);
+	QVERIFY(manager.bindingForDocument(&first) != manager.bindingForDocument(&second));
+	QTextCursor(&first).insertText(QStringLiteral("x"));
+	QTextCursor(&second).insertText(QStringLiteral("y"));
+	QCOMPARE(manager.bindingForDocument(&first)->version(), quint64(2));
+	QCOMPARE(manager.bindingForDocument(&second)->version(), quint64(2));
+	QCOMPARE(manager.bindingForDocument(&first)->shadow(), first.canonicalText());
+	QCOMPARE(manager.bindingForDocument(&second)->shadow(), second.canonicalText());
+}
+
+void LanguageServiceDocumentTest::completionCapabilityAndRequestContext()
+{
+	QTemporaryDir directory;
+	Tw::Document::TeXDocument unavailableDocument(QStringLiteral("abc"));
+	store(unavailableDocument, createFile(directory, QStringLiteral("unavailable.mkxl")));
+	LanguageServiceManager unavailableManager;
+	RecordingService * unavailable = configure(unavailableManager, capabilities());
+	unavailableManager.registerDocument(&unavailableDocument);
+	QVERIFY(!unavailableManager.canRequestCompletion(&unavailableDocument));
+	QVERIFY(!unavailableManager.requestCompletion(&unavailableDocument, languagePosition(0, 1)));
+	QCOMPARE(unavailable->operations.size(), 1);
+
+	LanguageServiceManager manager;
+	RecordingService * service = configure(manager, capabilities(TextSyncKind::Incremental, true, false, true));
+	Tw::Document::TeXDocument document(QString::fromUtf8("😀abc"));
+	store(document, createFile(directory, QStringLiteral("source.mkxl")));
+	manager.registerDocument(&document);
+	QVERIFY(manager.canRequestCompletion(&document));
+	QSignalSpy readySpy(&manager, SIGNAL(completionReady(Tw::Document::TeXDocument *, const QList<Tw::LanguageServices::CompletionItem> &)));
+	QVERIFY(manager.requestCompletion(&document, languagePosition(0, 3)));
+	QCOMPARE(service->operations.last().kind, Operation::Completion);
+	const LanguageCompletionRequest request = service->operations.last().completionRequest;
+	QCOMPARE(request.document, manager.bindingForDocument(&document)->url());
+	QCOMPARE(request.synchronizedVersion, quint64(1));
+	comparePosition(request.position, 0, 3);
+	CompletionItem item;
+	item.label = QStringLiteral("provider");
+	item.insertText = QStringLiteral("provider");
+	service->finishCompletion(request.token, QList<CompletionItem>{item});
+	QCOMPARE(readySpy.count(), 1);
+	QVERIFY(manager.requestCompletion(&document, languagePosition(0, 2)));
+	service->failCompletionRequest(service->operations.last().completionRequest.token);
+	QCOMPARE(readySpy.count(), 2);
+	QVERIFY(qvariant_cast<QList<CompletionItem>>(readySpy.last().at(1)).isEmpty());
+
+	QVERIFY(!manager.requestCompletion(&document, languagePosition(0, 99)));
+	service->acceptCompletionRequests = false;
+	QVERIFY(!manager.requestCompletion(&document, languagePosition(0, 1)));
+}
+
+void LanguageServiceDocumentTest::completionFreshness()
+{
+	QTemporaryDir directory;
+	LanguageServiceManager manager;
+	RecordingService * service = configure(manager, capabilities(TextSyncKind::Incremental, true, false, true));
+	Tw::Document::TeXDocument document(QStringLiteral("abc"));
+	store(document, createFile(directory, QStringLiteral("source.mkxl")));
+	manager.registerDocument(&document);
+	QSignalSpy readySpy(&manager, SIGNAL(completionReady(Tw::Document::TeXDocument *, const QList<Tw::LanguageServices::CompletionItem> &)));
+	CompletionItem item;
+	item.label = QStringLiteral("provider");
+	item.insertText = QStringLiteral("provider");
+
+	const auto requestToken = [&]() {
+		if (!manager.requestCompletion(&document, languagePosition(0, 1)))
+			return quint64(0);
+		return service->operations.last().completionRequest.token;
+	};
+	quint64 token = requestToken();
+	QVERIFY(token != 0);
+	QTextCursor(&document).insertText(QStringLiteral("x"));
+	service->finishCompletion(token, QList<CompletionItem>{item});
+	QCOMPARE(readySpy.count(), 0);
+
+	token = requestToken();
+	QVERIFY(token != 0);
+	manager.cancelCompletionRequest(&document);
+	service->finishCompletion(token, QList<CompletionItem>{item});
+	QCOMPARE(readySpy.count(), 0);
+
+	token = requestToken();
+	QVERIFY(token != 0);
+	manager.beginCompletionEdit(&document);
+	QTextCursor cursor(&document);
+	cursor.setPosition(0);
+	cursor.insertText(QStringLiteral("p"));
+	manager.endCompletionEdit(&document);
+	service->finishCompletion(token, QList<CompletionItem>{item});
+	QCOMPARE(readySpy.count(), 1);
+
+	token = requestToken();
+	QVERIFY(token != 0);
+	store(document, createFile(directory, QStringLiteral("renamed.mkxl")));
+	manager.updateDocumentIdentity(&document);
+	service->finishCompletion(token, QList<CompletionItem>{item});
+	QCOMPARE(readySpy.count(), 1);
+
+	const quint64 older = requestToken();
+	const quint64 newer = requestToken();
+	QVERIFY(older != 0 && newer != 0);
+	service->finishCompletion(older, QList<CompletionItem>{item});
+	QCOMPARE(readySpy.count(), 1);
+	service->finishCompletion(newer, QList<CompletionItem>{item});
+	QCOMPARE(readySpy.count(), 2);
+
+	token = requestToken();
+	QVERIFY(token != 0);
+	service->stop();
+	QVERIFY(service->start());
+	service->finishCompletion(token, QList<CompletionItem>{item});
+	QCOMPARE(readySpy.count(), 2);
+
+	Tw::Document::TeXDocument closing(QStringLiteral("close"));
+	store(closing, createFile(directory, QStringLiteral("closing.mkxl")));
+	manager.registerDocument(&closing);
+	QVERIFY(manager.requestCompletion(&closing, languagePosition(0, 1)));
+	const quint64 closingToken = service->operations.last().completionRequest.token;
+	manager.unregisterDocument(&closing);
+	service->finishCompletion(closingToken, QList<CompletionItem>{item});
+	QCOMPARE(readySpy.count(), 2);
+
+	token = requestToken();
+	QVERIFY(token != 0);
+	service->fail();
+	service->finishCompletion(token, QList<CompletionItem>{item});
+	QCOMPARE(readySpy.count(), 2);
+	manager.unregisterDocument(&document);
+	service->finishCompletion(token, QList<CompletionItem>{item});
+	QCOMPARE(readySpy.count(), 2);
+}
+
+void LanguageServiceDocumentTest::definitionCapabilityAndRequestContext()
+{
+	QTemporaryDir directory;
+	QVERIFY(directory.isValid());
+	Tw::Document::TeXDocument unavailableDocument(QString::fromUtf8("😀abc"));
+	store(unavailableDocument, createFile(directory, QStringLiteral("unavailable.mkxl")));
+	LanguageServiceManager unavailableManager;
+	RecordingService * unavailable = configure(unavailableManager, capabilities());
+	unavailableManager.registerDocument(&unavailableDocument);
+	QVERIFY(!unavailableManager.canRequestDefinition(&unavailableDocument));
+	QVERIFY(!unavailableManager.requestDefinition(&unavailableDocument, languagePosition(0, 2)));
+	QCOMPARE(unavailable->operations.size(), 1);
+
+	Tw::Document::TeXDocument document(QString::fromUtf8("😀abc"));
+	const QString path = createFile(directory, QStringLiteral("available.mkxl"));
+	store(document, path);
+	LanguageServiceManager manager;
+	RecordingService * service = configure(manager, capabilities(TextSyncKind::Incremental, true, true));
+	manager.registerDocument(&document);
+	QVERIFY(manager.canRequestDefinition(&document));
+	QVERIFY(manager.requestDefinition(&document, languagePosition(0, 3)));
+	QCOMPARE(service->operations.size(), 2);
+	const LanguageDefinitionRequest request = service->operations.last().definitionRequest;
+	QVERIFY(request.token != 0);
+	QCOMPARE(request.document, QUrl::fromLocalFile(QFileInfo(path).canonicalFilePath()));
+	QCOMPARE(request.synchronizedVersion, quint64(1));
+	QCOMPARE(request.position.line, 0);
+	QCOMPARE(request.position.character, 3);
+	QVERIFY(!manager.requestDefinition(&document, languagePosition(0, 99)));
+}
+
+void LanguageServiceDocumentTest::definitionFreshness()
+{
+	QTemporaryDir directory;
+	QVERIFY(directory.isValid());
+	LanguageServiceManager manager;
+	RecordingService * service = configure(manager, capabilities(TextSyncKind::Incremental, true, true));
+	Tw::Document::TeXDocument document(QStringLiteral("abc\ndef"));
+	store(document, createFile(directory, QStringLiteral("a.mkxl")));
+	manager.registerDocument(&document);
+	int acceptedResults = 0;
+	QList<LanguageLocation> acceptedLocations;
+	connect(&manager, &LanguageServiceManager::definitionReady, &manager,
+	        [&acceptedResults, &acceptedLocations, &document](Tw::Document::TeXDocument * resultDocument,
+	                                                        const QList<LanguageLocation> & locations) {
+		        if (resultDocument == &document) {
+			        ++acceptedResults;
+			        acceptedLocations = locations;
+		        }
+	        });
+	LanguageLocation location;
+	location.document = QUrl::fromLocalFile(QDir(directory.path()).filePath(QStringLiteral("target.mkxl")));
+	location.range.start = languagePosition(1, 0);
+	location.range.end = languagePosition(1, 3);
+	QVERIFY(manager.requestDefinition(&document, languagePosition(0, 1)));
+	quint64 token = service->operations.last().definitionRequest.token;
+	service->finishDefinition(token, QList<LanguageLocation>{});
+	QCOMPARE(acceptedResults, 1);
+	QVERIFY(acceptedLocations.isEmpty());
+	acceptedResults = 0;
+	QVERIFY(manager.requestDefinition(&document, languagePosition(0, 1)));
+	token = service->operations.last().definitionRequest.token;
+	service->finishDefinition(token, QList<LanguageLocation>{location, location});
+	QCOMPARE(acceptedResults, 1);
+	QCOMPARE(acceptedLocations.size(), 2);
+	acceptedResults = 0;
+
+	QVERIFY(manager.requestDefinition(&document, languagePosition(0, 1)));
+	token = service->operations.last().definitionRequest.token;
+	QTextCursor(&document).insertText(QStringLiteral("x"));
+	service->finishDefinition(token, QList<LanguageLocation>{location});
+	QCOMPARE(acceptedResults, 0);
+
+	QVERIFY(manager.requestDefinition(&document, languagePosition(0, 1)));
+	token = service->operations.last().definitionRequest.token;
+	store(document, createFile(directory, QStringLiteral("renamed.mkxl")));
+	manager.updateDocumentIdentity(&document);
+	service->finishDefinition(token, QList<LanguageLocation>{location});
+	QCOMPARE(acceptedResults, 0);
+
+	QVERIFY(manager.requestDefinition(&document, languagePosition(0, 1)));
+	const quint64 superseded = service->operations.last().definitionRequest.token;
+	QVERIFY(manager.requestDefinition(&document, languagePosition(0, 2)));
+	const quint64 current = service->operations.last().definitionRequest.token;
+	service->finishDefinition(superseded, QList<LanguageLocation>{location});
+	QCOMPARE(acceptedResults, 0);
+	service->finishDefinition(current, QList<LanguageLocation>{location});
+	QCOMPARE(acceptedResults, 1);
+	QCOMPARE(acceptedLocations.size(), 1);
+	QVERIFY(manager.requestDefinition(&document, languagePosition(0, 1)));
+	token = service->operations.last().definitionRequest.token;
+	manager.cancelDefinitionRequest(&document);
+	service->finishDefinition(token, QList<LanguageLocation>{location});
+	QCOMPARE(acceptedResults, 1);
+
+	QVERIFY(manager.requestDefinition(&document, languagePosition(0, 1)));
+	token = service->operations.last().definitionRequest.token;
+	service->fail();
+	service->finishDefinition(token, QList<LanguageLocation>{location});
+	QCOMPARE(acceptedResults, 1);
+	QVERIFY(!manager.canRequestDefinition(&document));
+	service->stop();
+	QVERIFY(service->start());
+	QVERIFY(manager.canRequestDefinition(&document));
+	service->finishDefinition(token, QList<LanguageLocation>{location});
+	QCOMPARE(acceptedResults, 1);
+
+	QVERIFY(manager.requestDefinition(&document, languagePosition(0, 1)));
+	token = service->operations.last().definitionRequest.token;
+	manager.unregisterDocument(&document);
+	service->finishDefinition(token, QList<LanguageLocation>{location});
+	QCOMPARE(acceptedResults, 1);
+}
+
+void LanguageServiceDocumentTest::definitionUnavailableDocuments()
+{
+	Tw::Document::TeXDocument document(QStringLiteral("abc"));
+	LanguageServiceManager noService;
+	noService.registerDocument(&document);
+	QVERIFY(!noService.canRequestDefinition(&document));
+	QVERIFY(!noService.requestDefinition(&document, languagePosition(0, 0)));
+
+	LanguageServiceManager manager;
+	RecordingService * service = configure(manager, capabilities(TextSyncKind::Incremental, true, true));
+	manager.registerDocument(&document);
+	QVERIFY(!manager.canRequestDefinition(&document));
+	QVERIFY(!manager.requestDefinition(&document, languagePosition(0, 0)));
+	QVERIFY(service->operations.isEmpty());
+}
+
+void LanguageServiceDocumentTest::definitionRangeConversion()
+{
+	QTextDocument document(QString::fromUtf8("a😀b\nsecond"));
+	QTextCursor cursor;
+	LanguageRange range;
+	range.start = languagePosition(0, 1);
+	range.end = languagePosition(0, 3);
+	QVERIFY(cursorForLanguageRange(&document, range, cursor));
+	QCOMPARE(cursor.selectionStart(), 1);
+	QCOMPARE(cursor.selectionEnd(), 3);
+	QCOMPARE(cursor.selectedText(), QString::fromUtf8("😀"));
+
+	range.start = languagePosition(0, 3);
+	range.end = languagePosition(1, 3);
+	QVERIFY(cursorForLanguageRange(&document, range, cursor));
+	QCOMPARE(cursor.selectionStart(), 3);
+	QCOMPARE(cursor.selectionEnd(), 8);
+
+	const QList<LanguageRange> invalidRanges = [&]() {
+		QList<LanguageRange> ranges;
+		LanguageRange invalid;
+		invalid.start = languagePosition(-1, 0);
+		invalid.end = languagePosition(0, 0);
+		ranges.append(invalid);
+		invalid.start = languagePosition(0, 99);
+		invalid.end = languagePosition(0, 99);
+		ranges.append(invalid);
+		invalid.start = languagePosition(9, 0);
+		invalid.end = languagePosition(9, 0);
+		ranges.append(invalid);
+		invalid.start = languagePosition(1, 1);
+		invalid.end = languagePosition(0, 1);
+		ranges.append(invalid);
+		invalid.start = languagePosition(0, 3);
+		invalid.end = languagePosition(0, 2);
+		ranges.append(invalid);
+		return ranges;
+	}();
+	for (const LanguageRange & invalid : invalidRanges) {
+		QTextCursor unchanged(&document);
+		unchanged.setPosition(2);
+		QVERIFY(!cursorForLanguageRange(&document, invalid, unchanged));
+		QCOMPARE(unchanged.position(), 2);
+	}
+}
+
+QTEST_MAIN(LanguageServiceDocumentTest)

--- a/unit-tests/LanguageServiceDocument_test.h
+++ b/unit-tests/LanguageServiceDocument_test.h
@@ -1,0 +1,46 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+#ifndef LANGUAGESERVICEDOCUMENT_TEST_H
+#define LANGUAGESERVICEDOCUMENT_TEST_H
+
+#include <QObject>
+
+class LanguageServiceDocumentTest : public QObject
+{
+	Q_OBJECT
+
+private slots:
+	void eligibility();
+	void texIntentChanges();
+	void deferredRefreshIsolation();
+	void deferredRefreshLifecycle();
+	void unsavedThenStored();
+	void openCloseCapability();
+	void syncNone();
+	void fullSynchronization();
+	void incrementalChanges_data();
+	void incrementalChanges();
+	void undoRedo();
+	void sameIdentityIsSilent();
+	void identityAndEligibilityTransitions();
+	void reloadSynchronizes();
+	void serviceLifecycleAndGeneration();
+	void replacementKeepsDocumentBinding();
+	void closeLifecycle();
+	void multipleDocumentsShareService();
+	void completionCapabilityAndRequestContext();
+	void completionFreshness();
+	void definitionCapabilityAndRequestContext();
+	void definitionFreshness();
+	void definitionUnavailableDocuments();
+	void definitionRangeConversion();
+};
+
+#endif // LANGUAGESERVICEDOCUMENT_TEST_H

--- a/unit-tests/LanguageServiceDocument_test_support.cpp
+++ b/unit-tests/LanguageServiceDocument_test_support.cpp
@@ -1,0 +1,17 @@
+/* Test-only TeXHighlighter stubs for TeXDocument. */
+#include "TeXHighlighter.h"
+#include "document/TeXDocument.h"
+
+void NonblockingSyntaxHighlighter::setDocument(QTextDocument * document) { Q_UNUSED(document) }
+void NonblockingSyntaxHighlighter::rehighlight() { }
+void NonblockingSyntaxHighlighter::rehighlightBlock(const QTextBlock & block) { Q_UNUSED(block) }
+void NonblockingSyntaxHighlighter::maybeRehighlightText(int position, int charsRemoved, int charsAdded)
+{
+	Q_UNUSED(position)
+	Q_UNUSED(charsRemoved)
+	Q_UNUSED(charsAdded)
+}
+void NonblockingSyntaxHighlighter::process() { }
+void NonblockingSyntaxHighlighter::processWhenIdle() { }
+TeXHighlighter::TeXHighlighter(Tw::Document::TeXDocument * parent) : NonblockingSyntaxHighlighter(parent) { }
+void TeXHighlighter::highlightBlock(const QString & text) { Q_UNUSED(text) }

--- a/unit-tests/LanguageServiceNavigationWindow_test.cpp
+++ b/unit-tests/LanguageServiceNavigationWindow_test.cpp
@@ -12,6 +12,8 @@
 
 #include "DefaultEngineList.h"
 #include "Engine.h"
+#include "PrefsDialog.h"
+#include "Settings.h"
 #include "TWApp.h"
 #include "TeXDocumentWindow.h"
 #include "languageservices/LanguageService.h"
@@ -21,12 +23,17 @@
 #include "utils/ResourcesLibrary.h"
 
 #include <QAction>
+#include <QCheckBox>
 #include <QComboBox>
 #include <QDir>
 #include <QFile>
 #include <QHash>
+#include <QLineEdit>
 #include <QListView>
+#include <QPlainTextEdit>
+#include <QPushButton>
 #include <QStandardPaths>
+#include <QStatusBar>
 #include <QTemporaryDir>
 #include <QTimer>
 #include <QtTest>
@@ -180,6 +187,15 @@ private:
 	TWApp * app;
 	QList<Engine> originalEngines;
 };
+
+QString fakeServerPath()
+{
+	QString name = QStringLiteral("language_server_fake");
+#ifdef Q_OS_WIN
+	name += QStringLiteral(".exe");
+#endif
+	return QDir(QCoreApplication::applicationDirPath()).filePath(name);
+}
 
 } // namespace
 
@@ -586,6 +602,209 @@ void LanguageServiceNavigationWindowTest::completionPreviewUndoRedoSynchronizati
 	QTRY_VERIFY(TWApp::instance()->languageServiceManager().service() == nullptr);
 	window->setModified(false);
 	window->close();
+	QTRY_VERIFY(TeXDocumentWindow::documentList().isEmpty());
+}
+
+void LanguageServiceNavigationWindowTest::productionConfigurationActivation()
+{
+	QVERIFY(!TWApp::instance()->languageServiceSettings().enabled);
+	QCOMPARE(TWApp::instance()->languageServiceManager().state(), LanguageService::NotConfigured);
+	QVERIFY(TWApp::instance()->languageServiceManager().service() == nullptr);
+
+	QTemporaryDir directory;
+	QVERIFY(directory.isValid());
+	const QString sourcePath = writeFile(directory, QStringLiteral("already-open.mkxl"), QStringLiteral("\\starttext\n\\stoptext\n"));
+	const QString logPath = QDir(directory.path()).filePath(QStringLiteral("documents.jsonl"));
+	TeXDocumentWindow * source = new TeXDocumentWindow(sourcePath);
+	source->show();
+	QAction * definition = source->findChild<QAction *>(QStringLiteral("actionGo_to_Definition"));
+	QVERIFY(definition);
+	QVERIFY(!definition->isEnabled());
+
+	Tw::LanguageServiceSettings settings;
+	settings.enabled = true;
+	settings.executable = fakeServerPath();
+	settings.arguments = QStringList{QStringLiteral("--lsp-profile"), QStringLiteral("digestif"),
+	                                 QStringLiteral("--document-log"), logPath,
+	                                 QStringLiteral("literal argument with spaces")};
+	TWApp::instance()->setLanguageServiceSettings(settings);
+	QCOMPARE(TWApp::instance()->languageServiceSettings(), settings);
+	QTRY_COMPARE(TWApp::instance()->languageServiceManager().state(), LanguageService::Ready);
+	LanguageService * sharedService = TWApp::instance()->languageServiceManager().service();
+	QVERIFY(sharedService != nullptr);
+	QCOMPARE(sharedService->parent(), &TWApp::instance()->languageServiceManager());
+	QTRY_VERIFY(definition->isEnabled());
+	QTRY_VERIFY(TWApp::instance()->languageServiceManager().bindingForDocument(source->textDoc())->isSynchronized());
+
+	const QString secondPath = writeFile(directory, QStringLiteral("second.mkxl"), QStringLiteral("second\n"));
+	TeXDocumentWindow * second = new TeXDocumentWindow(secondPath);
+	second->show();
+	QTRY_VERIFY(TWApp::instance()->languageServiceManager().bindingForDocument(second->textDoc())->isSynchronized());
+	QCOMPARE(TWApp::instance()->languageServiceManager().service(), sharedService);
+
+	settings.enabled = false;
+	TWApp::instance()->setLanguageServiceSettings(settings);
+	QTRY_VERIFY(TWApp::instance()->languageServiceManager().service() == nullptr);
+	QVERIFY(!definition->isEnabled());
+	QCOMPARE(TWApp::instance()->languageServiceSettings(), settings);
+	second->close();
+	source->close();
+	QTRY_VERIFY(TeXDocumentWindow::documentList().isEmpty());
+}
+
+void LanguageServiceNavigationWindowTest::productionConfigurationFailures()
+{
+	QTemporaryDir directory;
+	QVERIFY(directory.isValid());
+	const QString sourcePath = writeFile(directory, QStringLiteral("failure.mkxl"), QStringLiteral("adlen"));
+	TeXDocumentWindow * source = new TeXDocumentWindow(sourcePath);
+	source->show();
+	source->selectWindow();
+
+	Tw::LanguageServiceSettings settings;
+	settings.enabled = true;
+	TWApp::instance()->setLanguageServiceSettings(settings);
+	QVERIFY(TWApp::instance()->languageServiceManager().service() == nullptr);
+	QVERIFY(TWApp::instance()->languageServiceStatusText().contains(QStringLiteral("Choose a language server executable")));
+
+	const QString marker = QDir(directory.path()).filePath(QStringLiteral("shell-was-used"));
+	settings.executable = QStringLiteral("missing-language-server;touch %1").arg(marker);
+	TWApp::instance()->setLanguageServiceSettings(settings);
+	QTRY_COMPARE(TWApp::instance()->languageServiceManager().state(), LanguageService::Failed);
+	QVERIFY(!QFileInfo::exists(marker));
+	QTRY_VERIFY(source->statusBar()->currentMessage().contains(QStringLiteral("Language server unavailable")));
+
+	source->editor()->setFocus();
+	QTextCursor cursor = source->editor()->textCursor();
+	cursor.movePosition(QTextCursor::End);
+	source->editor()->setTextCursor(cursor);
+	QTest::keyClick(source->editor(), Qt::Key_Tab);
+	QCOMPARE(source->editor()->toPlainText(), QString::fromUtf8("\\addtolength{}{\u2022}\n"));
+
+	settings.executable = fakeServerPath();
+	settings.arguments = QStringList{QStringLiteral("--lsp-profile"), QStringLiteral("initialize-error")};
+	TWApp::instance()->setLanguageServiceSettings(settings);
+	QTRY_COMPARE(TWApp::instance()->languageServiceManager().state(), LanguageService::Failed);
+	QVERIFY(TWApp::instance()->languageServiceStatusText().contains(QStringLiteral("scripted initialize failure")));
+
+	settings.arguments = QStringList{QStringLiteral("--lsp-profile"), QStringLiteral("exit-after-initialized")};
+	TWApp::instance()->setLanguageServiceSettings(settings);
+	QTRY_COMPARE(TWApp::instance()->languageServiceManager().state(), LanguageService::Failed);
+	QVERIFY(TWApp::instance()->languageServiceStatusText().contains(QStringLiteral("exited unexpectedly")));
+
+	settings.enabled = false;
+	TWApp::instance()->setLanguageServiceSettings(settings);
+	QTRY_VERIFY(TWApp::instance()->languageServiceManager().service() == nullptr);
+	source->setModified(false);
+	source->close();
+	QTRY_VERIFY(TeXDocumentWindow::documentList().isEmpty());
+}
+
+void LanguageServiceNavigationWindowTest::pathCommandActivation()
+{
+	QTemporaryDir directory;
+	QVERIFY(directory.isValid());
+	const QString commandName = QStringLiteral("tw-language-server-path-test");
+#ifdef Q_OS_WIN
+	const QString installedCommand = QDir(directory.path()).filePath(commandName + QStringLiteral(".exe"));
+#else
+	const QString installedCommand = QDir(directory.path()).filePath(commandName);
+#endif
+	QVERIFY(QFile::copy(fakeServerPath(), installedCommand));
+	QVERIFY(QFile::setPermissions(installedCommand, QFile::permissions(fakeServerPath())));
+	const QByteArray oldPath = qgetenv("PATH");
+	const QByteArray temporaryPath = QFile::encodeName(directory.path());
+	qputenv("PATH", oldPath.isEmpty() ? temporaryPath : temporaryPath + QByteArray(PATH_LIST_SEP) + oldPath);
+
+	Tw::LanguageServiceSettings settings;
+	settings.enabled = true;
+	settings.executable = commandName;
+	settings.arguments = QStringList{QStringLiteral("--lsp-profile"), QStringLiteral("digestif")};
+	TWApp::instance()->setLanguageServiceSettings(settings);
+	QTRY_COMPARE(TWApp::instance()->languageServiceManager().state(), LanguageService::Ready);
+	QCOMPARE(TWApp::instance()->languageServiceSettings().executable, commandName);
+	settings.enabled = false;
+	TWApp::instance()->setLanguageServiceSettings(settings);
+	QTRY_VERIFY(TWApp::instance()->languageServiceManager().service() == nullptr);
+	qputenv("PATH", oldPath);
+}
+
+void LanguageServiceNavigationWindowTest::preferencesLanguageServicesUi()
+{
+	Tw::LanguageServiceSettings initial;
+	initial.enabled = false;
+	initial.executable = QStringLiteral("server-command");
+	initial.arguments = QStringList{QStringLiteral("--literal value"), QStringLiteral("quoted=\"unchanged\"")};
+	TWApp::instance()->setLanguageServiceSettings(initial);
+
+	QTimer::singleShot(0, this, SLOT(acceptLanguageServicesPreferences()));
+	QCOMPARE(PrefsDialog::doPrefsDialog(nullptr), QDialog::Accepted);
+	const Tw::LanguageServiceSettings applied = TWApp::instance()->languageServiceSettings();
+	QVERIFY(applied.enabled);
+	QCOMPARE(applied.executable, fakeServerPath());
+	QCOMPARE(applied.arguments, QStringList({QStringLiteral("--lsp-profile"), QStringLiteral("digestif"),
+	                                        QStringLiteral("--completion-mode"), QStringLiteral("label")}));
+	QTRY_COMPARE(TWApp::instance()->languageServiceManager().state(), LanguageService::Ready);
+
+	Tw::LanguageServiceSettings disabled = applied;
+	disabled.enabled = false;
+	TWApp::instance()->setLanguageServiceSettings(disabled);
+	QTRY_VERIFY(TWApp::instance()->languageServiceManager().service() == nullptr);
+}
+
+void LanguageServiceNavigationWindowTest::acceptLanguageServicesPreferences()
+{
+	auto * dialog = qobject_cast<PrefsDialog *>(QApplication::activeModalWidget());
+	QVERIFY(dialog != nullptr);
+	auto * enabled = dialog->findChild<QCheckBox *>(QStringLiteral("languageServicesEnabled"));
+	auto * executable = dialog->findChild<QLineEdit *>(QStringLiteral("languageServerExecutable"));
+	auto * arguments = dialog->findChild<QPlainTextEdit *>(QStringLiteral("languageServerArguments"));
+	auto * browse = dialog->findChild<QPushButton *>(QStringLiteral("browseLanguageServer"));
+	QVERIFY(enabled && executable && arguments && browse);
+	QVERIFY(!enabled->isChecked());
+	QVERIFY(!executable->isEnabled());
+	QVERIFY(!arguments->isEnabled());
+	QCOMPARE(executable->text(), QStringLiteral("server-command"));
+	QCOMPARE(arguments->toPlainText(), QStringLiteral("--literal value\nquoted=\"unchanged\""));
+	enabled->setChecked(true);
+	QVERIFY(executable->isEnabled());
+	QVERIFY(arguments->isEnabled());
+	executable->setText(fakeServerPath());
+	arguments->setPlainText(QStringLiteral("--lsp-profile\ndigestif\n--completion-mode\nlabel"));
+	dialog->accept();
+}
+
+void LanguageServiceNavigationWindowTest::optionalConfiguredProductionServer()
+{
+	const QString executable = QString::fromLocal8Bit(qgetenv("TEXWORKS_LANGUAGE_SERVER"));
+	if (executable.isEmpty())
+		QSKIP("Set TEXWORKS_LANGUAGE_SERVER to validate a real provider through production activation");
+	QVERIFY2(QFileInfo::exists(executable), qPrintable(executable));
+
+	QTemporaryDir directory;
+	QVERIFY(directory.isValid());
+	const QString sourcePath = writeFile(directory, QStringLiteral("real-provider.mkxl"),
+	                                    QStringLiteral("\\starttext\n\\chapter{One}\n\\stoptext\n"));
+	TeXDocumentWindow * source = new TeXDocumentWindow(sourcePath);
+	source->show();
+	QAction * definition = source->findChild<QAction *>(QStringLiteral("actionGo_to_Definition"));
+	QVERIFY(definition);
+	QVERIFY(!definition->isEnabled());
+
+	Tw::LanguageServiceSettings settings;
+	settings.enabled = true;
+	settings.executable = executable;
+	TWApp::instance()->setLanguageServiceSettings(settings);
+	QTRY_COMPARE_WITH_TIMEOUT(TWApp::instance()->languageServiceManager().state(), LanguageService::Ready, 15000);
+	QVERIFY(TWApp::instance()->languageServiceManager().capabilities().completion);
+	QVERIFY(TWApp::instance()->languageServiceManager().capabilities().definition);
+	QTRY_VERIFY(TWApp::instance()->languageServiceManager().bindingForDocument(source->textDoc())->isSynchronized());
+	QTRY_VERIFY(definition->isEnabled());
+
+	settings.enabled = false;
+	TWApp::instance()->setLanguageServiceSettings(settings);
+	QTRY_VERIFY_WITH_TIMEOUT(TWApp::instance()->languageServiceManager().service() == nullptr, 5000);
+	source->close();
 	QTRY_VERIFY(TeXDocumentWindow::documentList().isEmpty());
 }
 

--- a/unit-tests/LanguageServiceNavigationWindow_test.cpp
+++ b/unit-tests/LanguageServiceNavigationWindow_test.cpp
@@ -1,0 +1,823 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+
+#include "LanguageServiceNavigationWindow_test.h"
+
+#include "DefaultEngineList.h"
+#include "Engine.h"
+#include "TWApp.h"
+#include "TeXDocumentWindow.h"
+#include "languageservices/LanguageService.h"
+#include "languageservices/LanguageServiceDocumentBinding.h"
+#include "languageservices/LanguageServiceManager.h"
+#include "utils/IniConfig.h"
+#include "utils/ResourcesLibrary.h"
+
+#include <QAction>
+#include <QComboBox>
+#include <QDir>
+#include <QFile>
+#include <QHash>
+#include <QListView>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+#include <QTimer>
+#include <QtTest>
+
+using namespace Tw::LanguageServices;
+
+namespace {
+
+class RecordingDefinitionService : public LanguageService
+{
+public:
+	bool start() override
+	{
+		if (!beginStart())
+			return false;
+		setState(Initializing);
+		LanguageServiceCapabilities capabilities;
+		capabilities.textSync = TextSyncKind::Incremental;
+		capabilities.openClose = true;
+		capabilities.completion = true;
+		capabilities.definition = true;
+		becomeReady(capabilities);
+		return true;
+	}
+	void stop() override
+	{
+		if (state() == Stopped)
+			return;
+		setState(Stopping);
+		becomeStopped();
+	}
+	bool openDocument(const LanguageDocumentOpen & document) override
+	{
+		openedDocuments.append(document);
+		providerDocuments.insert(document.url, document.text);
+		return true;
+	}
+	bool changeDocument(const QUrl & url, quint64 version, const LanguageDocumentChange & change) override
+	{
+		if (!providerDocuments.contains(url))
+			return false;
+		if (!change.hasRange) {
+			providerDocuments.insert(url, change.text);
+		}
+		else {
+			QString & text = providerDocuments[url];
+			const auto offset = [&text](const LanguagePosition & position) {
+				int line = 0;
+				int result = 0;
+				while (line < position.line && result < text.size()) {
+					const int newline = static_cast<int>(text.indexOf(QLatin1Char('\n'), result));
+					if (newline < 0)
+						return -1;
+					result = newline + 1;
+					++line;
+				}
+				return line == position.line && position.character >= 0
+				           && position.character <= text.size() - result ? result + position.character : -1;
+			};
+			const int start = offset(change.range.start);
+			const int end = offset(change.range.end);
+			if (start < 0 || end < start)
+				return false;
+			text.replace(start, end - start, change.text);
+		}
+		changedVersions.append(version);
+		return true;
+	}
+	bool closeDocument(const QUrl &) override { return true; }
+	bool requestCompletion(const LanguageCompletionRequest & request) override
+	{
+		completionRequests.append(request);
+		return true;
+	}
+	bool requestDefinition(const LanguageDefinitionRequest & request) override
+	{
+		requests.append(request);
+		return true;
+	}
+	void finish(const QList<LanguageLocation> & locations)
+	{
+		Q_ASSERT(!requests.isEmpty());
+		emit definitionFinished(requests.last().token, locations);
+	}
+	void finishCompletion(int index, const QList<CompletionItem> & items)
+	{
+		Q_ASSERT(index >= 0 && index < completionRequests.size());
+		emit completionFinished(completionRequests.at(index).token, items);
+	}
+	void fail() { becomeFailed(QStringLiteral("scripted failure")); }
+
+	QList<LanguageDefinitionRequest> requests;
+	QList<LanguageCompletionRequest> completionRequests;
+	QList<LanguageDocumentOpen> openedDocuments;
+	QList<quint64> changedVersions;
+	QHash<QUrl, QString> providerDocuments;
+};
+
+QString writeFile(QTemporaryDir & directory, const QString & name, const QString & text)
+{
+	const QString path = QDir(directory.path()).filePath(name);
+	QFile file(path);
+	if (!file.open(QIODevice::WriteOnly) || file.write(text.toUtf8()) != text.toUtf8().size())
+		return {};
+	return path;
+}
+
+LanguagePosition position(int line, int character)
+{
+	LanguagePosition result;
+	result.line = line;
+	result.character = character;
+	return result;
+}
+
+LanguageLocation location(const QString & path, int startLine, int startCharacter,
+	                      int endLine, int endCharacter)
+{
+	LanguageLocation result;
+	result.document = QUrl::fromLocalFile(path);
+	result.range.start = position(startLine, startCharacter);
+	result.range.end = position(endLine, endCharacter);
+	return result;
+}
+
+const Engine * findEngine(const QList<Engine> & engines, const QString & name)
+{
+	for (const Engine & engine : engines) {
+		if (engine.name() == name)
+			return &engine;
+	}
+	return nullptr;
+}
+
+class EngineListRestorer
+{
+public:
+	explicit EngineListRestorer(TWApp * application)
+
+		: app(application)
+		, originalEngines(application->getEngineList())
+	{
+	}
+
+	~EngineListRestorer()
+	{
+		app->setEngineList(originalEngines);
+	}
+
+private:
+	TWApp * app;
+	QList<Engine> originalEngines;
+};
+
+} // namespace
+
+void LanguageServiceNavigationWindowTest::engineMetadataPersistence()
+{
+	EngineListRestorer restoreEngines(TWApp::instance());
+	QList<Engine> engines = TWApp::instance()->getEngineList();
+	const Engine * luaMetaTeX = findEngine(engines, QStringLiteral("ConTeXt (LuaMetaTeX)"));
+	const Engine * luaTeX = findEngine(engines, QStringLiteral("ConTeXt (LuaTeX)"));
+	const Engine * historicalPdfTeX = findEngine(engines, QStringLiteral("ConTeXt (pdfTeX)"));
+	const Engine * historicalXeTeX = findEngine(engines, QStringLiteral("ConTeXt (XeTeX)"));
+	const Engine * pdfLaTeX = findEngine(engines, QStringLiteral("pdfLaTeX"));
+	const Engine * lookalike = nullptr;
+	for (const Engine & engine : engines) {
+		if (engine.name() == QStringLiteral("ConTeXt (LuaMetaTeX)")
+		    && engine.program() == QStringLiteral("unrelated")) {
+			lookalike = &engine;
+			break;
+		}
+	}
+	QVERIFY(luaMetaTeX != nullptr);
+	QVERIFY(luaTeX != nullptr);
+	QVERIFY(historicalPdfTeX != nullptr);
+	QVERIFY(historicalXeTeX != nullptr);
+	QVERIFY(pdfLaTeX != nullptr);
+	QVERIFY(lookalike != nullptr);
+	QCOMPARE(luaMetaTeX->sourceLanguage(), QStringLiteral("context"));
+	QCOMPARE(luaTeX->sourceLanguage(), QStringLiteral("context"));
+	QCOMPARE(historicalPdfTeX->sourceLanguage(), QStringLiteral("context"));
+	QCOMPARE(historicalXeTeX->sourceLanguage(), QStringLiteral("context"));
+	QVERIFY(pdfLaTeX->sourceLanguage().isEmpty());
+	QVERIFY(lookalike->sourceLanguage().isEmpty());
+
+	const QString toolsPath = QDir(Tw::Utils::ResourcesLibrary::getPortableLibPath())
+	                              .filePath(QStringLiteral("configuration/tools.ini"));
+	{
+		Tw::Utils::IniConfig settings(toolsPath);
+		QCOMPARE(settings.value(QStringLiteral("007/language")).toString(), QStringLiteral("context"));
+		QVERIFY(!settings.contains(QStringLiteral("014/language")));
+	}
+
+	Engine renamed = *luaMetaTeX;
+	renamed.setName(QStringLiteral("My renamed tool"));
+	QCOMPARE(renamed.sourceLanguage(), QStringLiteral("context"));
+	for (int i = 0; i < engines.size(); ++i) {
+		if (engines.at(i).program() == luaMetaTeX->program()
+		    && engines.at(i).arguments() == luaMetaTeX->arguments()) {
+			engines[i] = renamed;
+			break;
+		}
+	}
+	TWApp::instance()->setEngineList(engines);
+	QCOMPARE(TWApp::instance()->getNamedEngine(renamed.name()).sourceLanguage(), QStringLiteral("context"));
+
+	Tw::Utils::IniConfig settings(toolsPath);
+	QCOMPARE(settings.value(QStringLiteral("007/name")).toString(), renamed.name());
+	QCOMPARE(settings.value(QStringLiteral("007/language")).toString(), QStringLiteral("context"));
+	QVERIFY(!settings.contains(QStringLiteral("014/language")));
+
+	Tw::Document::TeXDocument document;
+	document.setFileInfo(QFileInfo(QStringLiteral("renamed.tex")));
+	QCOMPARE(LanguageServiceManager::identifyLanguageId(&document, renamed.sourceLanguage()), QStringLiteral("context"));
+}
+
+void LanguageServiceNavigationWindowTest::staticCompletionRegression()
+{
+	TeXDocumentWindow * window = new TeXDocumentWindow;
+	window->show();
+	CompletingEdit * editor = window->editor();
+	editor->setFocus();
+
+	editor->setPlainText(QStringLiteral("adlen"));
+	QTextCursor cursor = editor->textCursor();
+	cursor.movePosition(QTextCursor::End);
+	editor->setTextCursor(cursor);
+	QTest::keyClick(editor, Qt::Key_Tab);
+	QCOMPARE(editor->toPlainText(), QString::fromUtf8("\\addtolength{}{\u2022}\n"));
+	QCOMPARE(editor->textCursor().position(), 13);
+	QVERIFY(editor->extraSelections().size() >= 1);
+
+	QTest::keyClick(editor, Qt::Key_Right);
+	QTest::qWait(300);
+	QCOMPARE(editor->extraSelections().size(), 1);
+
+	editor->setPlainText(QStringLiteral("--"));
+	cursor = editor->textCursor();
+	cursor.movePosition(QTextCursor::End);
+	editor->setTextCursor(cursor);
+	QTest::keyClick(editor, Qt::Key_Tab);
+	QCOMPARE(editor->toPlainText(), QStringLiteral("\\textendash"));
+	QTest::keyClick(editor, Qt::Key_Down);
+	QCOMPARE(editor->toPlainText(), QStringLiteral("\\textendash\\ "));
+	QTest::keyClick(editor, Qt::Key_Tab);
+
+	editor->clear();
+	QTest::keyClick(editor, Qt::Key_Tab);
+	QCOMPARE(editor->toPlainText(), QStringLiteral("\t"));
+
+	editor->setPlainText(QString::fromUtf8("before\u2022after"));
+	cursor = editor->textCursor();
+	cursor.setPosition(0);
+	editor->setTextCursor(cursor);
+	QTest::keyClick(editor, Qt::Key_Tab, Qt::ControlModifier);
+	QCOMPARE(editor->textCursor().selectedText(), QString(QChar(0x2022)));
+
+	editor->setPlainText(QStringLiteral("one\ntwo"));
+	cursor = editor->textCursor();
+	cursor.setPosition(0);
+	cursor.setPosition(static_cast<int>(editor->toPlainText().size()), QTextCursor::KeepAnchor);
+	editor->setTextCursor(cursor);
+	QTest::keyClick(editor, Qt::Key_Tab);
+	QCOMPARE(editor->toPlainText(), QStringLiteral("\tone\n\ttwo"));
+
+	window->setModified(false);
+	window->close();
+	QTRY_VERIFY(TeXDocumentWindow::documentList().isEmpty());
+}
+
+void LanguageServiceNavigationWindowTest::completionCandidateList()
+{
+	TeXDocumentWindow * window = new TeXDocumentWindow;
+	window->show();
+	CompletingEdit * editor = window->editor();
+	editor->setFocus();
+	editor->setPlainText(QStringLiteral("\\startsec"));
+	QTextCursor cursor = editor->textCursor();
+	cursor.movePosition(QTextCursor::End);
+	editor->setTextCursor(cursor);
+	QTest::keyClick(editor, Qt::Key_Tab);
+	auto * list = editor->findChild<QListView *>(QStringLiteral("completionList"));
+	QVERIFY(list);
+	QVERIFY(list->isVisible());
+	QVERIFY(list->model()->rowCount() >= 2);
+	QCOMPARE(list->model()->index(0, 0).data().toString(), QStringLiteral("\\startsection"));
+	QCOMPARE(list->currentIndex().row(), 0);
+	QCOMPARE(editor->toPlainText(), QStringLiteral("\\startsection"));
+
+	QTest::keyClick(editor, Qt::Key_Down);
+	QCOMPARE(list->currentIndex().row(), 1);
+	QCOMPARE(editor->toPlainText(), QStringLiteral("\\startsectionblock"));
+	QTest::keyClick(editor, Qt::Key_Escape);
+	QCOMPARE(editor->toPlainText(), QStringLiteral("\\startsec"));
+	QVERIFY(!list->isVisible());
+
+	QTest::keyClick(editor, Qt::Key_Tab);
+	QTest::keyClick(editor, Qt::Key_Return);
+	QCOMPARE(editor->toPlainText(), QStringLiteral("\\startsection"));
+	QVERIFY(!list->isVisible());
+	window->setModified(false);
+	window->close();
+	QTRY_VERIFY(TeXDocumentWindow::documentList().isEmpty());
+}
+
+void LanguageServiceNavigationWindowTest::completionCandidateListDeactivation()
+{
+	TeXDocumentWindow * window = new TeXDocumentWindow;
+	window->show();
+	CompletingEdit * editor = window->editor();
+	editor->setFocus();
+	editor->setPlainText(QStringLiteral("\\startsec"));
+	QTextCursor cursor = editor->textCursor();
+	cursor.movePosition(QTextCursor::End);
+	editor->setTextCursor(cursor);
+	QTest::keyClick(editor, Qt::Key_Tab);
+	auto * list = editor->findChild<QListView *>(QStringLiteral("completionList"));
+	QVERIFY(list && list->isVisible());
+	QCOMPARE(editor->toPlainText(), QStringLiteral("\\startsection"));
+	window->activateWindow();
+	QTRY_VERIFY(window->isActiveWindow());
+
+	QWidget otherWindow;
+	otherWindow.show();
+	otherWindow.raise();
+	otherWindow.activateWindow();
+	QTRY_VERIFY(!window->isActiveWindow());
+	QCOMPARE(editor->toPlainText(), QStringLiteral("\\startsec"));
+	QVERIFY(!list->isVisible());
+
+	window->setModified(false);
+	window->close();
+	otherWindow.close();
+	QTRY_VERIFY(TeXDocumentWindow::documentList().isEmpty());
+}
+
+void LanguageServiceNavigationWindowTest::completionCandidateListProviderIntegration()
+{
+	QTemporaryDir directory;
+	QVERIFY(directory.isValid());
+	const QString firstPath = writeFile(directory, QStringLiteral("first.mkxl"), QStringLiteral("adlen"));
+	const QString secondPath = writeFile(directory, QStringLiteral("second.mkxl"), QStringLiteral("adlen"));
+	QVERIFY(!firstPath.isEmpty());
+	QVERIFY(!secondPath.isEmpty());
+
+	RecordingDefinitionService * service = new RecordingDefinitionService;
+	QVERIFY(TWApp::instance()->languageServiceManager().setService(service, QStringList{QStringLiteral("context")}));
+	QVERIFY(TWApp::instance()->languageServiceManager().start());
+	TeXDocumentWindow * first = new TeXDocumentWindow(firstPath);
+	TeXDocumentWindow * second = new TeXDocumentWindow(secondPath);
+	first->show();
+	second->show();
+	auto openAtEnd = [](CompletingEdit * editor) {
+		editor->setFocus();
+		QTextCursor cursor = editor->textCursor();
+		cursor.movePosition(QTextCursor::End);
+		editor->setTextCursor(cursor);
+		QTest::keyClick(editor, Qt::Key_Tab);
+	};
+	auto listFor = [](CompletingEdit * editor) {
+		return editor->findChild<QListView *>(QStringLiteral("completionList"));
+	};
+
+	CompletingEdit * firstEditor = first->editor();
+	CompletingEdit * secondEditor = second->editor();
+	openAtEnd(firstEditor);
+	QCOMPARE(service->completionRequests.size(), 1);
+	QListView * firstList = listFor(firstEditor);
+	QVERIFY(firstList && firstList->isVisible());
+	const int staticRows = firstList->model()->rowCount();
+	QVERIFY(staticRows > 0);
+	const quint64 selectedId = firstList->currentIndex().data(Qt::UserRole).toULongLong();
+	const QString preview = firstEditor->toPlainText();
+	const int caret = firstEditor->textCursor().position();
+	const int initialWidth = firstList->width();
+	const int staticPresentationWidth = firstList->sizeHintForColumn(0);
+
+	CompletionItem duplicate;
+	duplicate.label = QStringLiteral("duplicate static");
+	duplicate.insertText = preview;
+	CompletionItem provider;
+	provider.label = QStringLiteral("provider completion item with an intentionally wider display label");
+	provider.insertText = QStringLiteral("providerInserted");
+	provider.hasReplacementRange = true;
+	provider.replacementRange.start = position(0, 0);
+	provider.replacementRange.end = position(0, 5);
+	CompletionItem sameLabelA;
+	sameLabelA.label = QStringLiteral("same label");
+	sameLabelA.insertText = QStringLiteral("sameA");
+	CompletionItem sameLabelB = sameLabelA;
+	sameLabelB.insertText = QStringLiteral("sameB");
+	service->finishCompletion(0, QList<CompletionItem>{duplicate, provider, sameLabelA, sameLabelA, sameLabelB});
+	QCOMPARE(firstList->model()->rowCount(), staticRows + 3);
+	QVERIFY(firstList->isVisible());
+	QCOMPARE(firstList->currentIndex().data(Qt::UserRole).toULongLong(), selectedId);
+	QCOMPARE(firstEditor->toPlainText(), preview);
+	QCOMPARE(firstEditor->textCursor().position(), caret);
+	QCOMPARE(firstList->model()->index(staticRows + 1, 0).data().toString(), QStringLiteral("same label"));
+	QCOMPARE(firstList->model()->index(staticRows + 2, 0).data().toString(), QStringLiteral("same label"));
+
+	const QModelIndex providerIndex = firstList->model()->index(staticRows, 0);
+	QCOMPARE(providerIndex.data().toString(), provider.label);
+	const int providerWidth = firstList->sizeHintForIndex(providerIndex).width();
+	QVERIFY(providerWidth > staticPresentationWidth);
+	QVERIFY(firstList->width() > initialWidth);
+	QVERIFY(firstList->viewport()->width() >= providerWidth);
+	QTest::mouseClick(firstList->viewport(), Qt::LeftButton, Qt::NoModifier, firstList->visualRect(providerIndex).center());
+	QCOMPARE(firstEditor->toPlainText(), QStringLiteral("providerInserted"));
+	const QString accepted = firstEditor->toPlainText();
+	QTest::keyClick(firstEditor, Qt::Key_Tab);
+	QCOMPARE(firstEditor->toPlainText(), accepted);
+	QVERIFY(!firstList->isVisible());
+
+	firstEditor->setPlainText(QStringLiteral("adlen"));
+	openAtEnd(firstEditor);
+	const int invalidRequest = static_cast<int>(service->completionRequests.size()) - 1;
+	QVERIFY(firstList->isVisible());
+	const int rowsBeforeInvalid = firstList->model()->rowCount();
+	CompletionItem invalid = provider;
+	invalid.replacementRange.start = position(1, 0);
+	invalid.replacementRange.end = position(1, 1);
+	service->finishCompletion(invalidRequest, QList<CompletionItem>{invalid});
+	QCOMPARE(firstList->model()->rowCount(), rowsBeforeInvalid);
+	QVERIFY(firstList->isVisible());
+
+	secondEditor->setPlainText(QStringLiteral("adlen"));
+	openAtEnd(secondEditor);
+	QListView * secondList = listFor(secondEditor);
+	QVERIFY(secondList && secondList->isVisible());
+	const int secondRows = secondList->model()->rowCount();
+	const quint64 secondId = secondList->currentIndex().data(Qt::UserRole).toULongLong();
+	const QString secondPreview = secondEditor->toPlainText();
+	firstEditor->setPlainText(QStringLiteral("adlen"));
+	openAtEnd(firstEditor);
+	const int appendRequest = static_cast<int>(service->completionRequests.size()) - 1;
+	service->finishCompletion(appendRequest, QList<CompletionItem>{sameLabelA});
+	QCOMPARE(firstList->model()->rowCount(), staticRows + 1);
+	QCOMPARE(secondList->model()->rowCount(), secondRows);
+	QCOMPARE(secondList->currentIndex().data(Qt::UserRole).toULongLong(), secondId);
+	QCOMPARE(secondEditor->toPlainText(), secondPreview);
+
+	firstEditor->setPlainText(QStringLiteral("providerPrefix"));
+	openAtEnd(firstEditor);
+	const int escapeRequest = static_cast<int>(service->completionRequests.size()) - 1;
+	QTest::keyClick(firstEditor, Qt::Key_Escape);
+	service->finishCompletion(escapeRequest, QList<CompletionItem>{sameLabelA});
+	QCOMPARE(firstEditor->toPlainText(), QStringLiteral("providerPrefix"));
+	QVERIFY(!firstList->isVisible());
+
+	firstEditor->setPlainText(QStringLiteral("adlen"));
+	openAtEnd(firstEditor);
+	const int oldRequest = static_cast<int>(service->completionRequests.size()) - 1;
+	QTest::keyClick(firstEditor, Qt::Key_X);
+	QCOMPARE(firstEditor->toPlainText(), QStringLiteral("adlenx"));
+	QCOMPARE(service->completionRequests.size(), oldRequest + 2);
+	service->finishCompletion(oldRequest, QList<CompletionItem>{sameLabelA});
+	QCOMPARE(firstEditor->toPlainText(), QStringLiteral("adlenx"));
+	service->finishCompletion(oldRequest + 1, QList<CompletionItem>{sameLabelB});
+	QCOMPARE(firstEditor->toPlainText(), QStringLiteral("sameB"));
+	QTest::keyClick(firstEditor, Qt::Key_Escape);
+
+	firstEditor->setPlainText(QStringLiteral("adlen"));
+	openAtEnd(firstEditor);
+	const int backspaceRequest = static_cast<int>(service->completionRequests.size()) - 1;
+	QTest::keyClick(firstEditor, Qt::Key_Backspace);
+	QCOMPARE(firstEditor->toPlainText(), QString::fromUtf8("\\addtolength{}{\u2022}\n"));
+	QCOMPARE(service->completionRequests.size(), backspaceRequest + 2);
+	service->finishCompletion(backspaceRequest, QList<CompletionItem>{sameLabelA});
+	QCOMPARE(firstEditor->toPlainText(), QString::fromUtf8("\\addtolength{}{\u2022}\n"));
+	QTest::keyClick(firstEditor, Qt::Key_Escape);
+
+	service->fail();
+	QVERIFY(secondList->isVisible());
+	QTest::keyClick(secondEditor, Qt::Key_Tab);
+	QVERIFY(!secondList->isVisible());
+	QCOMPARE(secondEditor->toPlainText(), secondPreview);
+	second->setModified(false);
+	second->close();
+	first->setModified(false);
+	first->close();
+	QTRY_VERIFY(TeXDocumentWindow::documentList().isEmpty());
+	QVERIFY(TWApp::instance()->languageServiceManager().replaceService(nullptr));
+	QCOMPARE(TWApp::instance()->languageServiceManager().state(), LanguageService::NotConfigured);
+}
+
+void LanguageServiceNavigationWindowTest::completionPreviewUndoRedoSynchronization()
+{
+	QTemporaryDir directory;
+	QVERIFY(directory.isValid());
+	const QString sourcePath = writeFile(directory, QStringLiteral("preview-undo.mkxl"), QStringLiteral("--"));
+	TeXDocumentWindow * window = new TeXDocumentWindow(sourcePath);
+	window->show();
+	window->selectWindow();
+
+	auto * service = new RecordingDefinitionService;
+	QVERIFY(TWApp::instance()->languageServiceManager().setService(service, QStringList{QStringLiteral("context")}));
+	QVERIFY(TWApp::instance()->languageServiceManager().start());
+	LanguageServiceDocumentBinding * binding = TWApp::instance()->languageServiceManager().bindingForDocument(window->textDoc());
+	QVERIFY(binding);
+	QTRY_VERIFY(binding->isSynchronized());
+
+	const auto verifyState = [&]() {
+		QCOMPARE(window->textDoc()->canonicalText(), window->editor()->toPlainText());
+		QCOMPARE(binding->shadow(), window->textDoc()->canonicalText());
+		QCOMPARE(service->providerDocuments.value(QUrl::fromLocalFile(sourcePath)), window->textDoc()->canonicalText());
+	};
+	CompletingEdit * editor = window->editor();
+	editor->setFocus();
+	QTextCursor cursor = editor->textCursor();
+	cursor.movePosition(QTextCursor::End);
+	editor->setTextCursor(cursor);
+	verifyState();
+	const quint64 baseVersion = binding->version();
+
+	QTest::keyClick(editor, Qt::Key_Tab);
+	QCOMPARE(editor->toPlainText(), QStringLiteral("\\textendash"));
+	QCOMPARE(service->completionRequests.size(), 1);
+	verifyState();
+	QVERIFY(binding->version() > baseVersion);
+	const quint64 firstPreviewVersion = binding->version();
+
+	QTest::keyClick(editor, Qt::Key_Down);
+	const QString cycledPreview = editor->toPlainText();
+	QVERIFY(cycledPreview != QStringLiteral("--"));
+	QVERIFY(cycledPreview != QStringLiteral("\\textendash"));
+	verifyState();
+	QVERIFY(binding->version() > firstPreviewVersion);
+	quint64 restoredVersion = binding->version();
+	QTest::keyClick(editor, Qt::Key_Escape);
+	verifyState();
+	QVERIFY(binding->version() > restoredVersion);
+	QCOMPARE(editor->toPlainText(), QStringLiteral("--"));
+
+	QTest::keyClick(editor, Qt::Key_Z, Qt::ControlModifier);
+	QTRY_VERIFY(binding->version() > restoredVersion);
+	verifyState();
+	const QString undoText = editor->toPlainText();
+	QCOMPARE(undoText, cycledPreview);
+
+	CompletionItem late;
+	late.label = QStringLiteral("late");
+	late.insertText = QStringLiteral("late");
+	service->finishCompletion(0, QList<CompletionItem>{late});
+	QCOMPARE(editor->toPlainText(), undoText);
+	verifyState();
+
+	const quint64 undoVersion = binding->version();
+	QTest::keyClick(editor, Qt::Key_Z, Qt::ControlModifier | Qt::ShiftModifier);
+	QTRY_VERIFY(binding->version() > undoVersion);
+	verifyState();
+	QCOMPARE(editor->toPlainText(), QStringLiteral("--"));
+
+	for (int index = 1; index < service->changedVersions.size(); ++index)
+		QVERIFY(service->changedVersions.at(index) > service->changedVersions.at(index - 1));
+	QVERIFY(TWApp::instance()->languageServiceManager().replaceService(nullptr, {}));
+	QTRY_VERIFY(TWApp::instance()->languageServiceManager().service() == nullptr);
+	window->setModified(false);
+	window->close();
+	QTRY_VERIFY(TeXDocumentWindow::documentList().isEmpty());
+}
+
+void LanguageServiceNavigationWindowTest::actionAndNavigation()
+{
+	QTemporaryDir directory;
+	QVERIFY(directory.isValid());
+	const QString sourcePath = writeFile(directory, QStringLiteral("source.mkxl"), QString::fromUtf8("a😀b\nsource\n"));
+	const QString targetPath = writeFile(directory, QStringLiteral("target.mkxl"), QStringLiteral("first\ndefinition\n"));
+	QVERIFY(!sourcePath.isEmpty());
+	QVERIFY(!targetPath.isEmpty());
+
+	TeXDocumentWindow * source = new TeXDocumentWindow(sourcePath);
+	source->show();
+	QAction * action = source->findChild<QAction *>(QStringLiteral("actionGo_to_Definition"));
+	QVERIFY(action);
+	QVERIFY(!action->isEnabled());
+
+	RecordingDefinitionService * service = new RecordingDefinitionService;
+	QVERIFY(TWApp::instance()->languageServiceManager().setService(service, QStringList{QStringLiteral("context")}));
+	QVERIFY(TWApp::instance()->languageServiceManager().start());
+	QTRY_VERIFY(action->isEnabled());
+
+	const QString intentPath = writeFile(directory, QStringLiteral("intent.tex"), QStringLiteral("plain TeX source\n"));
+	QVERIFY(!intentPath.isEmpty());
+	const auto openedBeforeIntent = service->openedDocuments.size();
+	const QList<Engine> engines = TWApp::instance()->getEngineList();
+	const Engine * luaMetaTeX = findEngine(engines, QStringLiteral("ConTeXt (LuaMetaTeX)"));
+	QVERIFY(luaMetaTeX != nullptr);
+	QCOMPARE(luaMetaTeX->sourceLanguage(), QStringLiteral("context"));
+	TeXDocumentWindow * intentWindow = new TeXDocumentWindow(intentPath);
+	intentWindow->show();
+	QComboBox * engineSelector = nullptr;
+	for (QComboBox * candidate : intentWindow->findChildren<QComboBox *>()) {
+		if (candidate->findText(luaMetaTeX->name(), Qt::MatchFixedString) >= 0) {
+			engineSelector = candidate;
+			break;
+		}
+	}
+	QVERIFY(engineSelector != nullptr);
+	engineSelector->setCurrentIndex(engineSelector->findText(luaMetaTeX->name(), Qt::MatchFixedString));
+	QTRY_COMPARE(service->openedDocuments.size(), openedBeforeIntent + 1);
+	QCOMPARE(service->openedDocuments.last().languageId, QStringLiteral("context"));
+	QCOMPARE(service->openedDocuments.last().url, QUrl::fromLocalFile(intentPath));
+	intentWindow->close();
+	QTRY_COMPARE(TeXDocumentWindow::documentList().size(), 1);
+	const auto placeAtEnd = [](CompletingEdit * editor) {
+		QTextCursor cursor = editor->textCursor();
+		cursor.movePosition(QTextCursor::End);
+		editor->setTextCursor(cursor);
+		editor->setFocus();
+	};
+
+	source->editor()->setPlainText(QStringLiteral("adlen"));
+	placeAtEnd(source->editor());
+	QTest::keyClick(source->editor(), Qt::Key_Tab);
+	QCOMPARE(service->completionRequests.size(), 1);
+	QCOMPARE(source->editor()->toPlainText(), QString::fromUtf8("\\addtolength{}{\u2022}\n"));
+	CompletionItem duplicate;
+	duplicate.label = QStringLiteral("adlen");
+	duplicate.insertText = QString::fromUtf8("\\addtolength{}{\u2022}\n");
+	service->finishCompletion(0, QList<CompletionItem>{duplicate});
+	QTest::keyClick(source->editor(), Qt::Key_Tab);
+	QCOMPARE(source->editor()->toPlainText(), QString::fromUtf8("\\addtolength{}{\u2022}\n"));
+
+	source->editor()->setPlainText(QStringLiteral("providerPrefix"));
+	placeAtEnd(source->editor());
+	QTest::keyClick(source->editor(), Qt::Key_Tab);
+	QCOMPARE(service->completionRequests.size(), 2);
+	QCOMPARE(source->editor()->toPlainText(), QStringLiteral("providerPrefix"));
+	CompletionItem provider;
+	provider.label = QStringLiteral("providerLabel");
+	provider.insertText = QStringLiteral("providerInserted");
+	service->finishCompletion(1, QList<CompletionItem>{provider});
+	QCOMPARE(source->editor()->toPlainText(), QStringLiteral("providerInserted"));
+
+	source->editor()->setPlainText(QString::fromUtf8("😀pr"));
+	placeAtEnd(source->editor());
+	QTest::keyClick(source->editor(), Qt::Key_Tab);
+	QCOMPARE(service->completionRequests.size(), 3);
+	QCOMPARE(service->completionRequests.last().position.character, 4);
+	CompletionItem edit;
+	edit.label = QStringLiteral("providerEdit");
+	edit.insertText = QStringLiteral("providerEdit");
+	edit.hasReplacementRange = true;
+	edit.replacementRange.start = position(0, 2);
+	edit.replacementRange.end = position(0, 4);
+	service->finishCompletion(2, QList<CompletionItem>{edit});
+	QCOMPARE(source->editor()->toPlainText(), QString::fromUtf8("😀providerEdit"));
+
+	source->editor()->setPlainText(QStringLiteral("lateProvider"));
+	placeAtEnd(source->editor());
+	QTest::keyClick(source->editor(), Qt::Key_Tab);
+	QCOMPARE(service->completionRequests.size(), 4);
+	QTest::keyClick(source->editor(), Qt::Key_Left);
+	service->finishCompletion(3, QList<CompletionItem>{provider});
+	QCOMPARE(source->editor()->toPlainText(), QStringLiteral("lateProvider"));
+
+	source->editor()->setPlainText(QStringLiteral("invalidRange"));
+	placeAtEnd(source->editor());
+	QTest::keyClick(source->editor(), Qt::Key_Tab);
+	CompletionItem invalid = edit;
+	invalid.replacementRange.start = position(1, 0);
+	invalid.replacementRange.end = position(1, 1);
+	service->finishCompletion(4, QList<CompletionItem>{invalid});
+	QCOMPARE(source->editor()->toPlainText(), QStringLiteral("invalidRange"));
+
+	TeXDocumentWindow * isolated = new TeXDocumentWindow(targetPath);
+	isolated->show();
+	source->editor()->setPlainText(QStringLiteral("sourceOnly"));
+	placeAtEnd(source->editor());
+	QTest::keyClick(source->editor(), Qt::Key_Tab);
+	isolated->editor()->setPlainText(QStringLiteral("targetOnly"));
+	placeAtEnd(isolated->editor());
+	QTest::keyClick(isolated->editor(), Qt::Key_Tab);
+	QCOMPARE(service->completionRequests.size(), 7);
+	service->finishCompletion(5, QList<CompletionItem>{provider});
+	QCOMPARE(source->editor()->toPlainText(), QStringLiteral("providerInserted"));
+	QCOMPARE(isolated->editor()->toPlainText(), QStringLiteral("targetOnly"));
+	CompletionItem targetProvider = provider;
+	targetProvider.insertText = QStringLiteral("targetInserted");
+	service->finishCompletion(6, QList<CompletionItem>{targetProvider});
+	QCOMPARE(isolated->editor()->toPlainText(), QStringLiteral("targetInserted"));
+	isolated->setModified(false);
+	isolated->close();
+	QTRY_COMPARE(TeXDocumentWindow::documentList().size(), 1);
+
+	source->editor()->setPlainText(QString::fromUtf8("a😀b\nsource\n"));
+	QTextCursor requestCursor = source->textCursor();
+	requestCursor.setPosition(3);
+	source->editor()->setTextCursor(requestCursor);
+	action->trigger();
+	QCOMPARE(service->requests.size(), 1);
+	QCOMPARE(service->requests.last().position.line, 0);
+	QCOMPARE(service->requests.last().position.character, 3);
+
+	service->finish(QList<LanguageLocation>{location(sourcePath, 0, 1, 0, 3)});
+	QCOMPARE(TeXDocumentWindow::documentList().size(), 1);
+	QCOMPARE(source->textCursor().selectedText(), QString::fromUtf8("😀"));
+
+	action->trigger();
+	service->finish(QList<LanguageLocation>{location(targetPath, 1, 0, 1, 10)});
+	TeXDocumentWindow * target = TeXDocumentWindow::findDocument(targetPath);
+	QVERIFY(target);
+	QCOMPARE(TeXDocumentWindow::documentList().size(), 2);
+	QCOMPARE(target->textCursor().selectedText(), QStringLiteral("definition"));
+
+	source->selectWindow();
+	action->trigger();
+	service->finish(QList<LanguageLocation>{location(targetPath, 1, 0, 1, 3)});
+	QCOMPARE(TeXDocumentWindow::findDocument(targetPath), target);
+	QCOMPARE(TeXDocumentWindow::documentList().size(), 2);
+	QCOMPARE(target->textCursor().selectedText(), QStringLiteral("def"));
+
+	source->selectWindow();
+	action->trigger();
+	service->finish(QList<LanguageLocation>{location(targetPath, 1, 99, 1, 100)});
+	QCOMPARE(target->textCursor().selectedText(), QStringLiteral("def"));
+	QCOMPARE(TeXDocumentWindow::documentList().size(), 2);
+
+	const QString unopenedInvalidTargetPath = writeFile(directory, QStringLiteral("unopened-invalid-target.mkxl"), QStringLiteral("target\n"));
+	QVERIFY(!unopenedInvalidTargetPath.isEmpty());
+	QVERIFY(TeXDocumentWindow::findDocument(unopenedInvalidTargetPath) == nullptr);
+	const auto documentsBeforeInvalidUnopenedTarget = TeXDocumentWindow::documentList().size();
+	const QTextCursor sourceCursorBeforeInvalidUnopenedTarget = source->textCursor();
+	source->selectWindow();
+	action->trigger();
+	service->finish(QList<LanguageLocation>{location(unopenedInvalidTargetPath, 0, 99, 0, 100)});
+	QVERIFY(TeXDocumentWindow::findDocument(unopenedInvalidTargetPath) == nullptr);
+	QCOMPARE(TeXDocumentWindow::documentList().size(), documentsBeforeInvalidUnopenedTarget);
+	QCOMPARE(source->textCursor().position(), sourceCursorBeforeInvalidUnopenedTarget.position());
+	QCOMPARE(source->textCursor().anchor(), sourceCursorBeforeInvalidUnopenedTarget.anchor());
+	QCOMPARE(source->statusBar()->currentMessage(), QStringLiteral("Cannot open definition location"));
+
+	action->trigger();
+	LanguageLocation nonLocal = location(targetPath, 0, 0, 0, 1);
+	nonLocal.document = QUrl(QStringLiteral("untitled:definition"));
+	service->finish(QList<LanguageLocation>{nonLocal});
+	QCOMPARE(TeXDocumentWindow::documentList().size(), 2);
+
+	action->trigger();
+	service->finish(QList<LanguageLocation>{});
+	QCOMPARE(TeXDocumentWindow::documentList().size(), 2);
+	action->trigger();
+	service->finish(QList<LanguageLocation>{location(sourcePath, 0, 0, 0, 1),
+	                                               location(targetPath, 0, 0, 0, 1)});
+	QCOMPARE(TeXDocumentWindow::documentList().size(), 2);
+
+	service->fail();
+	QTRY_VERIFY(!action->isEnabled());
+	source->editor()->setPlainText(QStringLiteral("adlen"));
+	placeAtEnd(source->editor());
+	QTest::keyClick(source->editor(), Qt::Key_Tab);
+	QCOMPARE(source->editor()->toPlainText(), QString::fromUtf8("\\addtolength{}{\u2022}\n"));
+	target->close();
+	source->setModified(false);
+	source->close();
+	QTRY_VERIFY(TeXDocumentWindow::documentList().isEmpty());
+}
+
+int main(int argc, char * argv[])
+{
+	QStandardPaths::setTestModeEnabled(true);
+	QTemporaryDir library;
+	if (!library.isValid())
+		return 1;
+	qputenv("TW_INIPATH", QFile::encodeName(library.path()));
+	Tw::Utils::ResourcesLibrary::setPortableLibPath(library.path());
+	QDir configuration(QDir(library.path()).filePath(QStringLiteral("configuration")));
+	if (!configuration.mkpath(QStringLiteral(".")))
+		return 1;
+	{
+		Tw::Utils::IniConfig settings(configuration.filePath(QStringLiteral("tools.ini")));
+		int index = 0;
+		for (const Tw::DefaultEngineList::Definition & definition : Tw::DefaultEngineList::definitions()) {
+			settings.beginGroup(QStringLiteral("%1").arg(++index, 3, 10, QChar::fromLatin1('0')));
+			settings.setValue(QStringLiteral("name"), definition.name);
+			settings.setValue(QStringLiteral("program"), definition.program);
+			settings.setValue(QStringLiteral("arguments"), definition.arguments);
+			settings.setValue(QStringLiteral("showPdf"), definition.showPdf);
+			settings.endGroup();
+		}
+		settings.beginGroup(QStringLiteral("014"));
+		settings.setValue(QStringLiteral("name"), QStringLiteral("ConTeXt (LuaMetaTeX)"));
+		settings.setValue(QStringLiteral("program"), QStringLiteral("unrelated"));
+		settings.setValue(QStringLiteral("arguments"), QStringList{QStringLiteral("--custom")});
+		settings.setValue(QStringLiteral("showPdf"), false);
+		settings.endGroup();
+	}
+	int applicationArgc = 1;
+	char * applicationArgv[] = {argv[0], nullptr};
+	TWApp application(applicationArgc, applicationArgv);
+	LanguageServiceNavigationWindowTest test;
+	return QTest::qExec(&test, argc, argv);
+}

--- a/unit-tests/LanguageServiceNavigationWindow_test.h
+++ b/unit-tests/LanguageServiceNavigationWindow_test.h
@@ -1,0 +1,29 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+#ifndef LANGUAGESERVICENAVIGATIONWINDOW_TEST_H
+#define LANGUAGESERVICENAVIGATIONWINDOW_TEST_H
+
+#include <QObject>
+
+class LanguageServiceNavigationWindowTest : public QObject
+{
+	Q_OBJECT
+
+private slots:
+	void engineMetadataPersistence();
+	void staticCompletionRegression();
+	void completionCandidateList();
+	void completionCandidateListDeactivation();
+	void completionCandidateListProviderIntegration();
+	void completionPreviewUndoRedoSynchronization();
+	void actionAndNavigation();
+};
+
+#endif // LANGUAGESERVICENAVIGATIONWINDOW_TEST_H

--- a/unit-tests/LanguageServiceNavigationWindow_test.h
+++ b/unit-tests/LanguageServiceNavigationWindow_test.h
@@ -16,6 +16,9 @@ class LanguageServiceNavigationWindowTest : public QObject
 {
 	Q_OBJECT
 
+public slots:
+	void acceptLanguageServicesPreferences();
+
 private slots:
 	void engineMetadataPersistence();
 	void staticCompletionRegression();
@@ -23,6 +26,11 @@ private slots:
 	void completionCandidateListDeactivation();
 	void completionCandidateListProviderIntegration();
 	void completionPreviewUndoRedoSynchronization();
+	void productionConfigurationActivation();
+	void productionConfigurationFailures();
+	void pathCommandActivation();
+	void preferencesLanguageServicesUi();
+	void optionalConfiguredProductionServer();
 	void actionAndNavigation();
 };
 

--- a/unit-tests/LanguageServiceSession_test.cpp
+++ b/unit-tests/LanguageServiceSession_test.cpp
@@ -16,8 +16,10 @@
 #include <QCoreApplication>
 #include <QDir>
 #include <QElapsedTimer>
-#include <QFile>
 #include <QFileInfo>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
 #include <QPointer>
 #include <QSignalSpy>
 #include <QTemporaryDir>
@@ -26,6 +28,12 @@
 using Tw::LanguageServices::LanguageService;
 using Tw::LanguageServices::LanguageServiceCapabilities;
 using Tw::LanguageServices::LanguageServiceConfiguration;
+using Tw::LanguageServices::LanguageDocumentChange;
+using Tw::LanguageServices::LanguageDocumentOpen;
+using Tw::LanguageServices::LanguageCompletionRequest;
+using Tw::LanguageServices::CompletionItem;
+using Tw::LanguageServices::LanguageDefinitionRequest;
+using Tw::LanguageServices::LanguageLocation;
 using Tw::LanguageServices::LanguageServiceManager;
 using Tw::LanguageServices::TextSyncKind;
 using Tw::LanguageServices::Lsp::LspLanguageService;
@@ -83,6 +91,11 @@ public:
 			setState(Stopping);
 	}
 	void finishStop() { becomeStopped(); }
+	bool openDocument(const LanguageDocumentOpen &) override { return true; }
+	bool changeDocument(const QUrl &, quint64, const LanguageDocumentChange &) override { return true; }
+	bool closeDocument(const QUrl &) override { return true; }
+	bool requestCompletion(const LanguageCompletionRequest &) override { return false; }
+	bool requestDefinition(const LanguageDefinitionRequest &) override { return false; }
 };
 
 } // namespace
@@ -92,6 +105,8 @@ void LanguageServiceSessionTest::initTestCase()
 	qRegisterMetaType<LanguageService::State>("Tw::LanguageServices::LanguageService::State");
 	qRegisterMetaType<LanguageServiceCapabilities>("Tw::LanguageServices::LanguageServiceCapabilities");
 	qRegisterMetaType<TextSyncKind>("Tw::LanguageServices::TextSyncKind");
+	qRegisterMetaType<QList<LanguageLocation>>("QList<Tw::LanguageServices::LanguageLocation>");
+	qRegisterMetaType<QList<CompletionItem>>("QList<Tw::LanguageServices::CompletionItem>");
 	QVERIFY2(QFileInfo::exists(fakeServerPath()), qPrintable(fakeServerPath()));
 }
 
@@ -175,6 +190,185 @@ void LanguageServiceSessionTest::featureMapping()
 		QVERIFY(!disabled.references && !disabled.documentSymbols && !disabled.workspaceSymbols && !disabled.diagnostics);
 		stopAndWait(absent);
 	}
+}
+
+void LanguageServiceSessionTest::completionRequestMapping()
+{
+	QTemporaryDir directory;
+	QVERIFY(directory.isValid());
+	const QString logPath = QDir(directory.path()).filePath(QStringLiteral("completion.jsonl"));
+	LanguageServiceConfiguration config = configuration(QStringLiteral("digestif"));
+	config.arguments << QStringLiteral("--document-log") << logPath
+	                 << QStringLiteral("--completion-mode") << QStringLiteral("label");
+	LspLanguageService service(config, nullptr, 1000, 100, 100);
+	waitForReady(service);
+	QSignalSpy resultSpy(&service, SIGNAL(completionFinished(quint64, const QList<Tw::LanguageServices::CompletionItem> &)));
+	LanguageCompletionRequest request;
+	request.token = 41;
+	request.document = QUrl::fromLocalFile(QDir(directory.path()).filePath(QStringLiteral("space name.mkxl")));
+	request.synchronizedVersion = 7;
+	request.position.line = 2;
+	request.position.character = 3;
+	QVERIFY(service.requestCompletion(request));
+	QTRY_COMPARE(resultSpy.count(), 1);
+	QCOMPARE(resultSpy.first().at(0).toULongLong(), quint64(41));
+	QFile log(logPath);
+	QVERIFY(log.open(QIODevice::ReadOnly));
+	const QJsonObject message = QJsonDocument::fromJson(log.readLine().trimmed()).object();
+	QCOMPARE(message.value(QStringLiteral("method")).toString(), QStringLiteral("textDocument/completion"));
+	const QJsonObject params = message.value(QStringLiteral("params")).toObject();
+	QCOMPARE(params.value(QStringLiteral("textDocument")).toObject().value(QStringLiteral("uri")).toString(),
+	         request.document.toString(QUrl::FullyEncoded));
+	QCOMPARE(params.value(QStringLiteral("position")).toObject().value(QStringLiteral("line")).toInt(), 2);
+	QCOMPARE(params.value(QStringLiteral("position")).toObject().value(QStringLiteral("character")).toInt(), 3);
+	stopAndWait(service);
+}
+
+void LanguageServiceSessionTest::completionResults_data()
+{
+	QTest::addColumn<QString>("mode");
+	QTest::addColumn<int>("itemCount");
+	QTest::addColumn<bool>("fails");
+	QTest::newRow("null") << QStringLiteral("null") << 0 << false;
+	QTest::newRow("item array") << QStringLiteral("array") << 2 << false;
+	QTest::newRow("CompletionList") << QStringLiteral("list") << 2 << false;
+	QTest::newRow("label only") << QStringLiteral("label") << 1 << false;
+	QTest::newRow("insertText") << QStringLiteral("insert") << 1 << false;
+	QTest::newRow("TextEdit") << QStringLiteral("textedit") << 1 << false;
+	QTest::newRow("metadata") << QStringLiteral("metadata") << 1 << false;
+	QTest::newRow("delayed") << QStringLiteral("delayed") << 2 << false;
+	QTest::newRow("snippet excluded") << QStringLiteral("snippet") << 0 << false;
+	QTest::newRow("malformed item skipped") << QStringLiteral("malformed-item") << 0 << false;
+	QTest::newRow("invalid range skipped") << QStringLiteral("invalid-range") << 0 << false;
+	QTest::newRow("malformed result") << QStringLiteral("malformed") << 0 << true;
+	QTest::newRow("provider error") << QStringLiteral("error") << 0 << true;
+}
+
+void LanguageServiceSessionTest::completionResults()
+{
+	QFETCH(QString, mode);
+	QFETCH(int, itemCount);
+	QFETCH(bool, fails);
+	LanguageServiceConfiguration config = configuration(QStringLiteral("digestif"));
+	config.arguments << QStringLiteral("--completion-mode") << mode;
+	LspLanguageService service(config, nullptr, 1000, 100, 100);
+	waitForReady(service);
+	QSignalSpy resultSpy(&service, SIGNAL(completionFinished(quint64, const QList<Tw::LanguageServices::CompletionItem> &)));
+	QSignalSpy failureSpy(&service, SIGNAL(completionFailed(quint64, const QString &)));
+	LanguageCompletionRequest request;
+	request.token = 8;
+	request.document = QUrl::fromLocalFile(QStringLiteral("/tmp/source.mkxl"));
+	request.position.line = 0;
+	request.position.character = 2;
+	QVERIFY(service.requestCompletion(request));
+	if (fails) {
+		QTRY_COMPARE(failureSpy.count(), 1);
+		QCOMPARE(resultSpy.count(), 0);
+	}
+	else {
+		QTRY_COMPARE(resultSpy.count(), 1);
+		QCOMPARE(failureSpy.count(), 0);
+		const QList<CompletionItem> items = qvariant_cast<QList<CompletionItem>>(resultSpy.first().at(1));
+		QCOMPARE(items.size(), itemCount);
+		if (mode == QStringLiteral("label"))
+			QCOMPARE(items.first().insertText, items.first().label);
+		if (mode == QStringLiteral("insert"))
+			QCOMPARE(items.first().insertText, QStringLiteral("providerInsert"));
+		if (mode == QStringLiteral("textedit")) {
+			QVERIFY(items.first().hasReplacementRange);
+			QCOMPARE(items.first().replacementRange.start.character, 0);
+			QCOMPARE(items.first().replacementRange.end.character, 2);
+		}
+		if (mode == QStringLiteral("metadata")) {
+			QCOMPARE(items.first().detail, QStringLiteral("detail"));
+			QCOMPARE(items.first().documentation, QStringLiteral("documentation"));
+		}
+	}
+	stopAndWait(service);
+}
+
+void LanguageServiceSessionTest::definitionRequestMapping()
+{
+	QTemporaryDir directory;
+	QVERIFY(directory.isValid());
+	const QString logPath = QDir(directory.path()).filePath(QStringLiteral("definition.jsonl"));
+	LanguageServiceConfiguration config = configuration(QStringLiteral("digestif"));
+	config.arguments << QStringLiteral("--document-log") << logPath
+	                 << QStringLiteral("--definition-mode") << QStringLiteral("location");
+	LspLanguageService service(config, nullptr, 1000, 100, 100);
+	waitForReady(service);
+	QSignalSpy resultSpy(&service, SIGNAL(definitionFinished(quint64, const QList<Tw::LanguageServices::LanguageLocation> &)));
+	LanguageDefinitionRequest request;
+	request.token = 42;
+	request.document = QUrl::fromLocalFile(QDir(directory.path()).filePath(QStringLiteral("source.mkxl")));
+	request.synchronizedVersion = 7;
+	request.position.line = 2;
+	request.position.character = 3;
+	QVERIFY(service.requestDefinition(request));
+	QTRY_COMPARE(resultSpy.count(), 1);
+	QCOMPARE(resultSpy.first().at(0).toULongLong(), quint64(42));
+	const QList<LanguageLocation> locations = qvariant_cast<QList<LanguageLocation>>(resultSpy.first().at(1));
+	QCOMPARE(locations.size(), 1);
+	QCOMPARE(locations.first().document, request.document);
+	QCOMPARE(locations.first().range.start.line, 2);
+	QCOMPARE(locations.first().range.start.character, 3);
+	QCOMPARE(locations.first().range.end.character, 4);
+
+	QFile log(logPath);
+	QVERIFY(log.open(QIODevice::ReadOnly));
+	const QJsonObject message = QJsonDocument::fromJson(log.readLine().trimmed()).object();
+	QCOMPARE(message.value(QStringLiteral("method")).toString(), QStringLiteral("textDocument/definition"));
+	const QJsonObject params = message.value(QStringLiteral("params")).toObject();
+	QCOMPARE(params.value(QStringLiteral("textDocument")).toObject().value(QStringLiteral("uri")).toString(),
+	         request.document.toString(QUrl::FullyEncoded));
+	QCOMPARE(params.value(QStringLiteral("position")).toObject().value(QStringLiteral("line")).toInt(), 2);
+	QCOMPARE(params.value(QStringLiteral("position")).toObject().value(QStringLiteral("character")).toInt(), 3);
+	stopAndWait(service);
+}
+
+void LanguageServiceSessionTest::definitionResults_data()
+{
+	QTest::addColumn<QString>("mode");
+	QTest::addColumn<int>("locationCount");
+	QTest::addColumn<bool>("fails");
+	QTest::newRow("null") << QStringLiteral("null") << 0 << false;
+	QTest::newRow("Location") << QStringLiteral("location") << 1 << false;
+	QTest::newRow("Location array") << QStringLiteral("array") << 2 << false;
+	QTest::newRow("LocationLink array") << QStringLiteral("link") << 1 << false;
+	QTest::newRow("delayed Location") << QStringLiteral("delayed") << 1 << false;
+	QTest::newRow("non-file URI") << QStringLiteral("nonfile") << 1 << false;
+	QTest::newRow("malformed") << QStringLiteral("malformed") << 0 << true;
+	QTest::newRow("provider error") << QStringLiteral("error") << 0 << true;
+}
+
+void LanguageServiceSessionTest::definitionResults()
+{
+	QFETCH(QString, mode);
+	QFETCH(int, locationCount);
+	QFETCH(bool, fails);
+	LanguageServiceConfiguration config = configuration(QStringLiteral("digestif"));
+	config.arguments << QStringLiteral("--definition-mode") << mode;
+	LspLanguageService service(config, nullptr, 1000, 100, 100);
+	waitForReady(service);
+	QSignalSpy resultSpy(&service, SIGNAL(definitionFinished(quint64, const QList<Tw::LanguageServices::LanguageLocation> &)));
+	QSignalSpy failureSpy(&service, SIGNAL(definitionFailed(quint64, const QString &)));
+	LanguageDefinitionRequest request;
+	request.token = 9;
+	request.document = QUrl::fromLocalFile(QStringLiteral("/tmp/source.mkxl"));
+	QVERIFY(service.requestDefinition(request));
+	if (fails) {
+		QTRY_COMPARE(failureSpy.count(), 1);
+		QCOMPARE(resultSpy.count(), 0);
+	}
+	else {
+		QTRY_COMPARE(resultSpy.count(), 1);
+		QCOMPARE(failureSpy.count(), 0);
+		const QList<LanguageLocation> locations = qvariant_cast<QList<LanguageLocation>>(resultSpy.first().at(1));
+		QCOMPARE(locations.size(), locationCount);
+		if (mode == QStringLiteral("nonfile"))
+			QVERIFY(!locations.first().document.isLocalFile());
+	}
+	stopAndWait(service);
 }
 
 void LanguageServiceSessionTest::unknownCapabilitiesIgnored()
@@ -395,6 +589,79 @@ void LanguageServiceSessionTest::managerPendingReplacementOwnership()
 	QCOMPARE(manager.service(), static_cast<LanguageService *>(latestPending));
 }
 
+void LanguageServiceSessionTest::documentLifecycleMapping()
+{
+	QTemporaryDir directory;
+	QVERIFY(directory.isValid());
+	const QString logPath = QDir(directory.path()).filePath(QStringLiteral("documents.jsonl"));
+	LanguageServiceConfiguration config = configuration(QStringLiteral("digestif"));
+	config.arguments << QStringLiteral("--document-log") << logPath;
+	LspLanguageService service(config, nullptr, 1000, 100, 100);
+	waitForReady(service);
+
+	LanguageDocumentOpen open;
+	open.url = QUrl::fromLocalFile(QDir(directory.path()).filePath(QStringLiteral("space name.mkxl")));
+	open.languageId = QStringLiteral("context");
+	open.version = 1;
+	open.text = QString::fromUtf8("a😀\nb");
+	QVERIFY(service.openDocument(open));
+
+	LanguageDocumentChange full;
+	full.text = QStringLiteral("complete\ntext");
+	QVERIFY(service.changeDocument(open.url, 2, full));
+
+	LanguageDocumentChange incremental;
+	incremental.hasRange = true;
+	incremental.range.start.line = 0;
+	incremental.range.start.character = 1;
+	incremental.range.end.line = 0;
+	incremental.range.end.character = 3;
+	incremental.text = QStringLiteral("X");
+	QVERIFY(service.changeDocument(open.url, 3, incremental));
+	QVERIFY(service.closeDocument(open.url));
+
+	const auto loggedLineCount = [&logPath]() {
+		QFile current(logPath);
+		if (!current.open(QIODevice::ReadOnly))
+			return 0;
+		int count = 0;
+		while (!current.atEnd()) {
+			if (!current.readLine().trimmed().isEmpty())
+				++count;
+		}
+		return count;
+	};
+	QTRY_COMPARE(loggedLineCount(), 4);
+	QFile log(logPath);
+	QVERIFY(log.open(QIODevice::ReadOnly));
+	QList<QJsonObject> messages;
+	while (!log.atEnd()) {
+		const QJsonDocument document = QJsonDocument::fromJson(log.readLine().trimmed());
+		if (document.isObject())
+			messages.append(document.object());
+	}
+	QCOMPARE(messages.size(), 4);
+	QCOMPARE(messages.at(0).value(QStringLiteral("method")).toString(), QStringLiteral("textDocument/didOpen"));
+	const QJsonObject openItem = messages.at(0).value(QStringLiteral("params")).toObject()
+	                             .value(QStringLiteral("textDocument")).toObject();
+	QCOMPARE(openItem.value(QStringLiteral("uri")).toString(), open.url.toString(QUrl::FullyEncoded));
+	QCOMPARE(openItem.value(QStringLiteral("languageId")).toString(), QStringLiteral("context"));
+	QCOMPARE(openItem.value(QStringLiteral("version")).toInt(), 1);
+	QCOMPARE(openItem.value(QStringLiteral("text")).toString(), open.text);
+	const QJsonObject fullChange = messages.at(1).value(QStringLiteral("params")).toObject()
+	                               .value(QStringLiteral("contentChanges")).toArray().first().toObject();
+	QVERIFY(!fullChange.contains(QStringLiteral("range")));
+	QCOMPARE(fullChange.value(QStringLiteral("text")).toString(), full.text);
+	const QJsonObject rangedChange = messages.at(2).value(QStringLiteral("params")).toObject()
+	                                 .value(QStringLiteral("contentChanges")).toArray().first().toObject();
+	const QJsonObject range = rangedChange.value(QStringLiteral("range")).toObject();
+	QCOMPARE(range.value(QStringLiteral("start")).toObject().value(QStringLiteral("character")).toInt(), 1);
+	QCOMPARE(range.value(QStringLiteral("end")).toObject().value(QStringLiteral("character")).toInt(), 3);
+	QCOMPARE(rangedChange.value(QStringLiteral("text")).toString(), QStringLiteral("X"));
+	QCOMPARE(messages.at(3).value(QStringLiteral("method")).toString(), QStringLiteral("textDocument/didClose"));
+	stopAndWait(service);
+}
+
 void LanguageServiceSessionTest::optionalConfiguredServer()
 {
 	const QByteArray executable = qgetenv("TEXWORKS_TEST_LANGUAGE_SERVER");
@@ -415,6 +682,71 @@ void LanguageServiceSessionTest::optionalConfiguredServer()
 	QVERIFY(capabilities.documentSymbols);
 	QVERIFY(capabilities.workspaceSymbols);
 	QVERIFY(!capabilities.diagnostics);
+	QTemporaryDir directory;
+	QVERIFY(directory.isValid());
+	const QString rootPath = QDir(directory.path()).filePath(QStringLiteral("root.mkxl"));
+	const QString childPath = QDir(directory.path()).filePath(QStringLiteral("child.mkxl"));
+	const QString rootText = QStringLiteral("\\component[child]\n\\in[child:section]\n\\startsec\n");
+	const QString childText = QStringLiteral("\\startsection[title=Child,reference=child:section]\n\\stopsection\n");
+	for (const auto & entry : {qMakePair(rootPath, rootText), qMakePair(childPath, childText)}) {
+		QFile file(entry.first);
+		QVERIFY(file.open(QIODevice::WriteOnly));
+		QCOMPARE(file.write(entry.second.toUtf8()), static_cast<qint64>(entry.second.toUtf8().size()));
+	}
+	LanguageDocumentOpen open;
+	open.url = QUrl::fromLocalFile(rootPath);
+	open.languageId = QStringLiteral("context");
+	open.version = 1;
+	open.text = rootText;
+	QVERIFY(service.openDocument(open));
+	LanguageDocumentChange change;
+	change.hasRange = true;
+	change.range.start.line = 0;
+	change.range.start.character = 17;
+	change.range.end = change.range.start;
+	change.text = QString::fromUtf8("😀");
+	QVERIFY(service.changeDocument(open.url, 2, change));
+	LanguageDocumentOpen child;
+	child.url = QUrl::fromLocalFile(childPath);
+	child.languageId = QStringLiteral("context");
+	child.version = 1;
+	child.text = childText;
+	QVERIFY(service.openDocument(child));
+	QSignalSpy definitionSpy(&service, SIGNAL(definitionFinished(quint64, const QList<Tw::LanguageServices::LanguageLocation> &)));
+	LanguageDefinitionRequest definition;
+	definition.token = 77;
+	definition.document = open.url;
+	definition.synchronizedVersion = 2;
+	definition.position.line = 1;
+	definition.position.character = 5;
+	QVERIFY(service.requestDefinition(definition));
+	QTRY_COMPARE_WITH_TIMEOUT(definitionSpy.count(), 1, 5000);
+	const QList<LanguageLocation> locations = qvariant_cast<QList<LanguageLocation>>(definitionSpy.first().at(1));
+	QCOMPARE(locations.size(), 1);
+	QCOMPARE(QFileInfo(locations.first().document.toLocalFile()).canonicalFilePath(), QFileInfo(childPath).canonicalFilePath());
+	QVERIFY(locations.first().range.end.line > locations.first().range.start.line
+	        || locations.first().range.end.character >= locations.first().range.start.character);
+	QSignalSpy completionSpy(&service, SIGNAL(completionFinished(quint64, const QList<Tw::LanguageServices::CompletionItem> &)));
+	LanguageCompletionRequest completion;
+	completion.token = 78;
+	completion.document = open.url;
+	completion.synchronizedVersion = 2;
+	completion.position.line = 2;
+	completion.position.character = 9;
+	QVERIFY(service.requestCompletion(completion));
+	QTRY_COMPARE_WITH_TIMEOUT(completionSpy.count(), 1, 5000);
+	const QList<CompletionItem> completionItems = qvariant_cast<QList<CompletionItem>>(completionSpy.first().at(1));
+	QVERIFY(!completionItems.isEmpty());
+	bool foundStartSection = false;
+	for (const CompletionItem & item : completionItems) {
+		if (item.label.contains(QStringLiteral("startsection"), Qt::CaseInsensitive)) {
+			foundStartSection = true;
+			break;
+		}
+	}
+	QVERIFY(foundStartSection);
+	QVERIFY(service.closeDocument(child.url));
+	QVERIFY(service.closeDocument(open.url));
 	stopAndWait(service);
 }
 

--- a/unit-tests/LanguageServiceSession_test.cpp
+++ b/unit-tests/LanguageServiceSession_test.cpp
@@ -1,0 +1,421 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+
+#include "LanguageServiceSession_test.h"
+
+#include "languageservices/LanguageServiceManager.h"
+#include "languageservices/lsp/LspLanguageService.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QElapsedTimer>
+#include <QFile>
+#include <QFileInfo>
+#include <QPointer>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QtTest>
+
+using Tw::LanguageServices::LanguageService;
+using Tw::LanguageServices::LanguageServiceCapabilities;
+using Tw::LanguageServices::LanguageServiceConfiguration;
+using Tw::LanguageServices::LanguageServiceManager;
+using Tw::LanguageServices::TextSyncKind;
+using Tw::LanguageServices::Lsp::LspLanguageService;
+
+namespace {
+
+QString fakeServerPath()
+{
+	QString name = QStringLiteral("language_server_fake");
+#ifdef Q_OS_WIN
+	name += QStringLiteral(".exe");
+#endif
+	return QDir(QCoreApplication::applicationDirPath()).filePath(name);
+}
+
+LanguageServiceConfiguration configuration(const QString & profile)
+{
+	LanguageServiceConfiguration result;
+	result.executable = fakeServerPath();
+	result.arguments = {QStringLiteral("--lsp-profile"), profile};
+	return result;
+}
+
+void waitForReady(LspLanguageService & service)
+{
+	QVERIFY(service.start());
+	QTRY_COMPARE(service.state(), LanguageService::Ready);
+}
+
+void stopAndWait(LspLanguageService & service)
+{
+	service.stop();
+	QTRY_COMPARE(service.state(), LanguageService::Stopped);
+}
+
+bool capabilitiesAreEmpty(const LanguageServiceCapabilities & capabilities)
+{
+	return capabilities == LanguageServiceCapabilities{};
+}
+
+class ControlledStopService : public LanguageService
+{
+public:
+	bool start() override
+	{
+		if (!beginStart())
+			return false;
+		setState(Initializing);
+		becomeReady(LanguageServiceCapabilities{});
+		return true;
+	}
+	void stop() override
+	{
+		if (state() != Stopped)
+			setState(Stopping);
+	}
+	void finishStop() { becomeStopped(); }
+};
+
+} // namespace
+
+void LanguageServiceSessionTest::initTestCase()
+{
+	qRegisterMetaType<LanguageService::State>("Tw::LanguageServices::LanguageService::State");
+	qRegisterMetaType<LanguageServiceCapabilities>("Tw::LanguageServices::LanguageServiceCapabilities");
+	qRegisterMetaType<TextSyncKind>("Tw::LanguageServices::TextSyncKind");
+	QVERIFY2(QFileInfo::exists(fakeServerPath()), qPrintable(fakeServerPath()));
+}
+
+void LanguageServiceSessionTest::digestifLikeInitialize()
+{
+	LspLanguageService service(configuration(QStringLiteral("digestif")), nullptr, 1000, 100, 100);
+	QSignalSpy readinessSpy(&service, SIGNAL(readinessChanged(bool)));
+	QSignalSpy capabilitiesSpy(&service, SIGNAL(capabilitiesChanged(const Tw::LanguageServices::LanguageServiceCapabilities &)));
+	waitForReady(service);
+	const LanguageServiceCapabilities capabilities = service.capabilities();
+	QCOMPARE(capabilities.textSync, TextSyncKind::Incremental);
+	QVERIFY(capabilities.openClose);
+	QVERIFY(capabilities.completion);
+	QVERIFY(capabilities.signatureHelp);
+	QVERIFY(capabilities.hover);
+	QVERIFY(capabilities.definition);
+	QVERIFY(capabilities.references);
+	QVERIFY(capabilities.documentSymbols);
+	QVERIFY(capabilities.workspaceSymbols);
+	QVERIFY(!capabilities.diagnostics);
+	QCOMPARE(readinessSpy.count(), 1);
+	QVERIFY(capabilitiesSpy.count() >= 1);
+	stopAndWait(service);
+	QVERIFY(capabilitiesAreEmpty(service.capabilities()));
+}
+
+void LanguageServiceSessionTest::synchronizationMapping_data()
+{
+	QTest::addColumn<QString>("profile");
+	QTest::addColumn<TextSyncKind>("expected");
+	QTest::newRow("numeric incremental") << QStringLiteral("numeric-incremental") << TextSyncKind::Incremental;
+	QTest::newRow("object incremental") << QStringLiteral("digestif") << TextSyncKind::Incremental;
+	QTest::newRow("full") << QStringLiteral("full") << TextSyncKind::Full;
+	QTest::newRow("none") << QStringLiteral("none") << TextSyncKind::None;
+	QTest::newRow("absent") << QStringLiteral("omitted") << TextSyncKind::None;
+}
+
+void LanguageServiceSessionTest::synchronizationMapping()
+{
+	QFETCH(QString, profile);
+	QFETCH(TextSyncKind, expected);
+	LspLanguageService service(configuration(profile), nullptr, 1000, 100, 100);
+	waitForReady(service);
+	QCOMPARE(service.capabilities().textSync, expected);
+	stopAndWait(service);
+}
+
+void LanguageServiceSessionTest::openCloseMapping_data()
+{
+	QTest::addColumn<QString>("profile");
+	QTest::addColumn<bool>("expected");
+	QTest::newRow("true") << QStringLiteral("digestif") << true;
+	QTest::newRow("false") << QStringLiteral("open-close-false") << false;
+	QTest::newRow("absent") << QStringLiteral("open-close-absent") << false;
+}
+
+void LanguageServiceSessionTest::openCloseMapping()
+{
+	QFETCH(QString, profile);
+	QFETCH(bool, expected);
+	LspLanguageService service(configuration(profile), nullptr, 1000, 100, 100);
+	waitForReady(service);
+	QCOMPARE(service.capabilities().openClose, expected);
+	stopAndWait(service);
+}
+
+void LanguageServiceSessionTest::featureMapping()
+{
+	LspLanguageService present(configuration(QStringLiteral("digestif")), nullptr, 1000, 100, 100);
+	waitForReady(present);
+	const LanguageServiceCapabilities enabled = present.capabilities();
+	QVERIFY(enabled.completion && enabled.signatureHelp && enabled.hover && enabled.definition);
+	QVERIFY(enabled.references && enabled.documentSymbols && enabled.workspaceSymbols);
+	stopAndWait(present);
+
+	for (const QString & profile : {QStringLiteral("features-false"), QStringLiteral("omitted")}) {
+		LspLanguageService absent(configuration(profile), nullptr, 1000, 100, 100);
+		waitForReady(absent);
+		const LanguageServiceCapabilities disabled = absent.capabilities();
+		QVERIFY(!disabled.completion && !disabled.signatureHelp && !disabled.hover && !disabled.definition);
+		QVERIFY(!disabled.references && !disabled.documentSymbols && !disabled.workspaceSymbols && !disabled.diagnostics);
+		stopAndWait(absent);
+	}
+}
+
+void LanguageServiceSessionTest::unknownCapabilitiesIgnored()
+{
+	LspLanguageService service(configuration(QStringLiteral("unknown")), nullptr, 1000, 100, 100);
+	waitForReady(service);
+	QVERIFY(service.capabilities().completion);
+	stopAndWait(service);
+}
+
+void LanguageServiceSessionTest::positionEncoding_data()
+{
+	QTest::addColumn<QString>("profile");
+	QTest::addColumn<bool>("ready");
+	QTest::newRow("explicit UTF-16") << QStringLiteral("digestif") << true;
+	QTest::newRow("default UTF-16") << QStringLiteral("omitted") << true;
+	QTest::newRow("unsupported UTF-8") << QStringLiteral("utf8") << false;
+	QTest::newRow("unsupported UTF-32") << QStringLiteral("utf32") << false;
+}
+
+void LanguageServiceSessionTest::positionEncoding()
+{
+	QFETCH(QString, profile);
+	QFETCH(bool, ready);
+	LspLanguageService service(configuration(profile), nullptr, 1000, 50, 50);
+	QSignalSpy failureSpy(&service, SIGNAL(failed(const QString &)));
+	QVERIFY(service.start());
+	if (ready) {
+		QTRY_COMPARE(service.state(), LanguageService::Ready);
+		stopAndWait(service);
+	}
+	else {
+		QTRY_COMPARE(service.state(), LanguageService::Failed);
+		QCOMPARE(failureSpy.count(), 1);
+		QVERIFY(service.failureReason().contains(QStringLiteral("unsupported")));
+		QVERIFY(capabilitiesAreEmpty(service.capabilities()));
+	}
+}
+
+void LanguageServiceSessionTest::initializeFailure_data()
+{
+	QTest::addColumn<QString>("profile");
+	QTest::newRow("JSON-RPC error") << QStringLiteral("initialize-error");
+	QTest::newRow("malformed result") << QStringLiteral("malformed-initialize");
+	QTest::newRow("invalid sync shape") << QStringLiteral("invalid-sync");
+}
+
+void LanguageServiceSessionTest::initializeFailure()
+{
+	QFETCH(QString, profile);
+	LspLanguageService service(configuration(profile), nullptr, 1000, 50, 50);
+	QSignalSpy failureSpy(&service, SIGNAL(failed(const QString &)));
+	QVERIFY(service.start());
+	QTRY_COMPARE(service.state(), LanguageService::Failed);
+	QCOMPARE(failureSpy.count(), 1);
+	QVERIFY(!service.failureReason().isEmpty());
+	QVERIFY(capabilitiesAreEmpty(service.capabilities()));
+}
+
+void LanguageServiceSessionTest::processExitWhileInitializing()
+{
+	LspLanguageService service(configuration(QStringLiteral("initialize-exit")), nullptr, 1000, 50, 50);
+	QSignalSpy failureSpy(&service, SIGNAL(failed(const QString &)));
+	QVERIFY(service.start());
+	QTRY_COMPARE(service.state(), LanguageService::Failed);
+	QCOMPARE(failureSpy.count(), 1);
+	QVERIFY(capabilitiesAreEmpty(service.capabilities()));
+}
+
+void LanguageServiceSessionTest::unexpectedExitAfterReady()
+{
+	LspLanguageService service(configuration(QStringLiteral("exit-after-initialized")), nullptr, 1000, 50, 50);
+	QSignalSpy failureSpy(&service, SIGNAL(failed(const QString &)));
+	QVERIFY(service.start());
+	QTRY_COMPARE(service.state(), LanguageService::Failed);
+	QCOMPARE(failureSpy.count(), 1);
+	QVERIFY(capabilitiesAreEmpty(service.capabilities()));
+}
+
+void LanguageServiceSessionTest::unsupportedServerRequestIsRejected()
+{
+	QTemporaryDir directory;
+	QVERIFY(directory.isValid());
+	const QString confirmationPath = QDir(directory.path()).filePath(QStringLiteral("server-request.txt"));
+	LanguageServiceConfiguration config = configuration(QStringLiteral("unsupported-request"));
+	config.arguments << QStringLiteral("--confirmation-log") << confirmationPath;
+	LspLanguageService service(config, nullptr, 1000, 100, 100);
+	waitForReady(service);
+	QTRY_VERIFY(QFileInfo(confirmationPath).size() > 0);
+	stopAndWait(service);
+
+	QFile confirmation(confirmationPath);
+	QVERIFY(confirmation.open(QIODevice::ReadOnly));
+	QCOMPARE(confirmation.readAll(), QByteArrayLiteral("unsupported request rejected\n"));
+}
+
+void LanguageServiceSessionTest::gracefulShutdown()
+{
+	LspLanguageService service(configuration(QStringLiteral("digestif")), nullptr, 1000, 100, 100);
+	waitForReady(service);
+	service.stop();
+	QTRY_COMPARE(service.state(), LanguageService::Stopped);
+	QVERIFY(capabilitiesAreEmpty(service.capabilities()));
+}
+
+void LanguageServiceSessionTest::shutdownTimeoutIsBounded()
+{
+	LspLanguageService service(configuration(QStringLiteral("shutdown-timeout")), nullptr, 1000, 30, 30);
+	waitForReady(service);
+	QElapsedTimer elapsed;
+	elapsed.start();
+	service.stop();
+	QTRY_COMPARE(service.state(), LanguageService::Stopped);
+	QVERIFY(elapsed.elapsed() < 1000);
+	QVERIFY(capabilitiesAreEmpty(service.capabilities()));
+}
+
+void LanguageServiceSessionTest::stopDuringInitialization()
+{
+	LspLanguageService service(configuration(QStringLiteral("delayed-initialize")), nullptr, 1000, 30, 30);
+	QVERIFY(service.start());
+	QTRY_COMPARE(service.state(), LanguageService::Initializing);
+	service.stop();
+	QTRY_COMPARE(service.state(), LanguageService::Stopped);
+	QTest::qWait(350);
+	QCOMPARE(service.state(), LanguageService::Stopped);
+	QVERIFY(capabilitiesAreEmpty(service.capabilities()));
+}
+
+void LanguageServiceSessionTest::sessionGenerationIsDistinct()
+{
+	LspLanguageService first(configuration(QStringLiteral("omitted")), nullptr, 1000, 50, 50);
+	LspLanguageService second(configuration(QStringLiteral("omitted")), nullptr, 1000, 50, 50);
+	QVERIFY(first.start());
+	QVERIFY(second.start());
+	QVERIFY(first.generation() != 0);
+	QVERIFY(second.generation() != 0);
+	QVERIFY(first.generation() != second.generation());
+	first.stop();
+	second.stop();
+	QTRY_COMPARE(first.state(), LanguageService::Stopped);
+	QTRY_COMPARE(second.state(), LanguageService::Stopped);
+}
+
+void LanguageServiceSessionTest::managerOwnership()
+{
+	LanguageServiceManager manager;
+	QCOMPARE(manager.state(), LanguageService::NotConfigured);
+	QVERIFY(capabilitiesAreEmpty(manager.capabilities()));
+	LspLanguageService * service = new LspLanguageService(configuration(QStringLiteral("digestif")), nullptr, 1000, 100, 100);
+	QVERIFY(manager.setService(service));
+	QCOMPARE(service->parent(), &manager);
+	QVERIFY(manager.start());
+	QTRY_COMPARE(manager.state(), LanguageService::Ready);
+	QVERIFY(manager.capabilities().completion);
+	manager.stop();
+	QTRY_COMPARE(manager.state(), LanguageService::Stopped);
+	QVERIFY(capabilitiesAreEmpty(manager.capabilities()));
+}
+
+void LanguageServiceSessionTest::managerPendingReplacementOwnership()
+{
+	{
+		auto * manager = new LanguageServiceManager;
+		auto * active = new ControlledStopService;
+		auto * pending = new ControlledStopService;
+		QPointer<ControlledStopService> activeGuard(active);
+		QPointer<ControlledStopService> pendingGuard(pending);
+		int activeDestroyed = 0;
+		int pendingDestroyed = 0;
+		connect(active, &QObject::destroyed, [&activeDestroyed]() { ++activeDestroyed; });
+		connect(pending, &QObject::destroyed, [&pendingDestroyed]() { ++pendingDestroyed; });
+		QVERIFY(manager->setService(active));
+		QVERIFY(manager->start());
+		QVERIFY(manager->replaceService(pending));
+		QCOMPARE(pending->parent(), manager);
+
+		delete manager;
+		QVERIFY(activeGuard.isNull());
+		QVERIFY(pendingGuard.isNull());
+		QCOMPARE(activeDestroyed, 1);
+		QCOMPARE(pendingDestroyed, 1);
+	}
+
+	LanguageServiceManager manager;
+	auto * active = new ControlledStopService;
+	QVERIFY(manager.setService(active));
+	QVERIFY(manager.start());
+	const quint64 activeGeneration = active->generation();
+	auto * firstPending = new ControlledStopService;
+	QPointer<ControlledStopService> firstPendingGuard(firstPending);
+	int firstPendingDestroyed = 0;
+	connect(firstPending, &QObject::destroyed, [&firstPendingDestroyed]() { ++firstPendingDestroyed; });
+	QVERIFY(manager.replaceService(firstPending));
+	QVERIFY(manager.replaceService(firstPending));
+	QCOMPARE(firstPendingDestroyed, 0);
+
+	auto * latestPending = new ControlledStopService;
+	QPointer<ControlledStopService> latestPendingGuard(latestPending);
+	int latestPendingDestroyed = 0;
+	connect(latestPending, &QObject::destroyed, [&latestPendingDestroyed]() { ++latestPendingDestroyed; });
+	QVERIFY(manager.replaceService(latestPending));
+	QVERIFY(firstPendingGuard.isNull());
+	QCOMPARE(firstPendingDestroyed, 1);
+	QCOMPARE(latestPending->parent(), &manager);
+
+	active->finishStop();
+	QCOMPARE(manager.service(), static_cast<LanguageService *>(latestPending));
+	QCOMPARE(latestPending->state(), LanguageService::Ready);
+	QVERIFY(latestPending->generation() != activeGeneration);
+
+	auto * stoppedPending = new ControlledStopService;
+	QPointer<ControlledStopService> stoppedPendingGuard(stoppedPending);
+	QVERIFY(manager.replaceService(stoppedPending));
+	QCOMPARE(stoppedPending->parent(), &manager);
+	manager.stop();
+	QVERIFY(stoppedPendingGuard.isNull());
+	QCOMPARE(manager.service(), static_cast<LanguageService *>(latestPending));
+}
+
+void LanguageServiceSessionTest::optionalConfiguredServer()
+{
+	const QByteArray executable = qgetenv("TEXWORKS_TEST_LANGUAGE_SERVER");
+	if (executable.isEmpty())
+		QSKIP("TEXWORKS_TEST_LANGUAGE_SERVER is not set");
+	LanguageServiceConfiguration realConfiguration;
+	realConfiguration.executable = QString::fromLocal8Bit(executable);
+	LspLanguageService service(realConfiguration, nullptr, 10000, 1000, 1000);
+	waitForReady(service);
+	const LanguageServiceCapabilities capabilities = service.capabilities();
+	QCOMPARE(capabilities.textSync, TextSyncKind::Incremental);
+	QVERIFY(capabilities.openClose);
+	QVERIFY(capabilities.completion);
+	QVERIFY(capabilities.signatureHelp);
+	QVERIFY(capabilities.hover);
+	QVERIFY(capabilities.definition);
+	QVERIFY(capabilities.references);
+	QVERIFY(capabilities.documentSymbols);
+	QVERIFY(capabilities.workspaceSymbols);
+	QVERIFY(!capabilities.diagnostics);
+	stopAndWait(service);
+}
+
+QTEST_GUILESS_MAIN(LanguageServiceSessionTest)

--- a/unit-tests/LanguageServiceSession_test.h
+++ b/unit-tests/LanguageServiceSession_test.h
@@ -1,0 +1,44 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+#ifndef LANGUAGESERVICESESSION_TEST_H
+#define LANGUAGESERVICESESSION_TEST_H
+
+#include <QObject>
+
+class LanguageServiceSessionTest : public QObject
+{
+	Q_OBJECT
+
+private slots:
+	void initTestCase();
+	void digestifLikeInitialize();
+	void synchronizationMapping_data();
+	void synchronizationMapping();
+	void openCloseMapping_data();
+	void openCloseMapping();
+	void featureMapping();
+	void unknownCapabilitiesIgnored();
+	void positionEncoding_data();
+	void positionEncoding();
+	void initializeFailure_data();
+	void initializeFailure();
+	void processExitWhileInitializing();
+	void unexpectedExitAfterReady();
+	void unsupportedServerRequestIsRejected();
+	void gracefulShutdown();
+	void shutdownTimeoutIsBounded();
+	void stopDuringInitialization();
+	void sessionGenerationIsDistinct();
+	void managerOwnership();
+	void managerPendingReplacementOwnership();
+	void optionalConfiguredServer();
+};
+
+#endif // LANGUAGESERVICESESSION_TEST_H

--- a/unit-tests/LanguageServiceSession_test.h
+++ b/unit-tests/LanguageServiceSession_test.h
@@ -24,6 +24,12 @@ private slots:
 	void openCloseMapping_data();
 	void openCloseMapping();
 	void featureMapping();
+	void completionRequestMapping();
+	void completionResults_data();
+	void completionResults();
+	void definitionRequestMapping();
+	void definitionResults_data();
+	void definitionResults();
 	void unknownCapabilitiesIgnored();
 	void positionEncoding_data();
 	void positionEncoding();
@@ -38,6 +44,7 @@ private slots:
 	void sessionGenerationIsDistinct();
 	void managerOwnership();
 	void managerPendingReplacementOwnership();
+	void documentLifecycleMapping();
 	void optionalConfiguredServer();
 };
 

--- a/unit-tests/language_server_fake.cpp
+++ b/unit-tests/language_server_fake.cpp
@@ -27,13 +27,14 @@
 #include <QPair>
 #include <QStringList>
 #include <QThread>
+#include <QUrl>
 
 #include <cstdlib>
 #include <initializer_list>
 
 namespace {
 
-QJsonObject jsonObject(const std::initializer_list<QPair<QString, QJsonValue>> & values)
+QJsonObject jsonObject(std::initializer_list<QPair<QString, QJsonValue>> values)
 {
 	QJsonObject object;
 	for (const QPair<QString, QJsonValue> & value : values)
@@ -41,7 +42,7 @@ QJsonObject jsonObject(const std::initializer_list<QPair<QString, QJsonValue>> &
 	return object;
 }
 
-QJsonArray jsonArray(const std::initializer_list<QJsonValue> & values)
+QJsonArray jsonArray(std::initializer_list<QJsonValue> values)
 {
 	QJsonArray array;
 	for (const QJsonValue & value : values)
@@ -163,6 +164,45 @@ bool validInitializeRequest(const QJsonObject & request)
 	       && !params.value(QStringLiteral("capabilities")).toObject().contains(QStringLiteral("textDocument"));
 }
 
+bool validPosition(const QJsonValue & value)
+{
+	const QJsonObject position = value.toObject();
+	return value.isObject() && position.value(QStringLiteral("line")).isDouble()
+	       && position.value(QStringLiteral("character")).isDouble();
+}
+
+bool validDocumentNotification(const QJsonObject & request)
+{
+	const QString method = request.value(QStringLiteral("method")).toString();
+	const QJsonObject params = request.value(QStringLiteral("params")).toObject();
+	const QJsonObject document = params.value(QStringLiteral("textDocument")).toObject();
+	if (!params.value(QStringLiteral("textDocument")).isObject()
+	    || !document.value(QStringLiteral("uri")).isString()
+	    || !QUrl(document.value(QStringLiteral("uri")).toString()).isLocalFile())
+		return false;
+	if (method == QStringLiteral("textDocument/didOpen"))
+		return document.value(QStringLiteral("languageId")).isString()
+		       && document.value(QStringLiteral("version")).isDouble()
+		       && document.value(QStringLiteral("text")).isString();
+	if (method == QStringLiteral("textDocument/didClose"))
+		return true;
+	if (method != QStringLiteral("textDocument/didChange")
+	    || !document.value(QStringLiteral("version")).isDouble())
+		return false;
+	const QJsonArray changes = params.value(QStringLiteral("contentChanges")).toArray();
+	if (changes.size() != 1 || !changes.first().isObject())
+		return false;
+	const QJsonObject change = changes.first().toObject();
+	if (!change.value(QStringLiteral("text")).isString())
+		return false;
+	if (!change.contains(QStringLiteral("range")))
+		return true;
+	const QJsonObject range = change.value(QStringLiteral("range")).toObject();
+	return change.value(QStringLiteral("range")).isObject()
+	       && validPosition(range.value(QStringLiteral("start")))
+	       && validPosition(range.value(QStringLiteral("end")));
+}
+
 bool isUnsupportedRequestRejection(const QJsonObject & response)
 {
 	const QJsonObject error = response.value(QStringLiteral("error")).toObject();
@@ -186,6 +226,18 @@ int main(int argc, char * argv[])
 	const auto profileIndex = arguments.indexOf(QStringLiteral("--lsp-profile"));
 	const QString lspProfile = profileIndex >= 0 && profileIndex + 1 < arguments.size()
 	                         ? arguments.at(profileIndex + 1) : QString{};
+	const auto documentLogIndex = arguments.indexOf(QStringLiteral("--document-log"));
+	const QString documentLogPath = documentLogIndex >= 0 && documentLogIndex + 1 < arguments.size()
+	                              ? arguments.at(documentLogIndex + 1) : QString{};
+	const auto definitionModeIndex = arguments.indexOf(QStringLiteral("--definition-mode"));
+	const QString definitionMode = definitionModeIndex >= 0 && definitionModeIndex + 1 < arguments.size()
+	                             ? arguments.at(definitionModeIndex + 1) : QStringLiteral("location");
+	const auto definitionTargetIndex = arguments.indexOf(QStringLiteral("--definition-target"));
+	const QString definitionTarget = definitionTargetIndex >= 0 && definitionTargetIndex + 1 < arguments.size()
+	                               ? arguments.at(definitionTargetIndex + 1) : QString{};
+	const auto completionModeIndex = arguments.indexOf(QStringLiteral("--completion-mode"));
+	const QString completionMode = completionModeIndex >= 0 && completionModeIndex + 1 < arguments.size()
+	                             ? arguments.at(completionModeIndex + 1) : QStringLiteral("array");
 	const auto confirmationLogIndex = arguments.indexOf(QStringLiteral("--confirmation-log"));
 	const QString confirmationLogPath = confirmationLogIndex >= 0 && confirmationLogIndex + 1 < arguments.size()
 	                                  ? arguments.at(confirmationLogIndex + 1) : QString{};
@@ -203,6 +255,9 @@ int main(int argc, char * argv[])
 	QFile error;
 	if (!input.open(stdin, QIODevice::ReadOnly) || !output.open(stdout, QIODevice::WriteOnly)
 	    || !error.open(stderr, QIODevice::WriteOnly))
+		return 2;
+	QFile documentLog(documentLogPath);
+	if (!documentLogPath.isEmpty() && !documentLog.open(QIODevice::WriteOnly | QIODevice::Append))
 		return 2;
 	QFile confirmationLog(confirmationLogPath);
 	if (!confirmationLogPath.isEmpty() && !confirmationLog.open(QIODevice::WriteOnly | QIODevice::Append))
@@ -281,6 +336,156 @@ int main(int argc, char * argv[])
 					return 3;
 				unsupportedRequestPending = true;
 			}
+			continue;
+		}
+		if (method == QStringLiteral("textDocument/didOpen")
+		    || method == QStringLiteral("textDocument/didChange")
+		    || method == QStringLiteral("textDocument/didClose")) {
+			if (!initializedObserved || !validDocumentNotification(request))
+				return 5;
+			if (documentLog.isOpen()) {
+				documentLog.write(QJsonDocument(request).toJson(QJsonDocument::Compact));
+				documentLog.write("\n");
+				documentLog.flush();
+			}
+			continue;
+		}
+		if (method == QStringLiteral("textDocument/definition")) {
+			const QJsonObject params = request.value(QStringLiteral("params")).toObject();
+			const QJsonObject document = params.value(QStringLiteral("textDocument")).toObject();
+			const QJsonValue positionValue = params.value(QStringLiteral("position"));
+			if (!initializedObserved || !document.value(QStringLiteral("uri")).isString()
+			    || !validPosition(positionValue))
+				return 6;
+			if (documentLog.isOpen()) {
+				documentLog.write(QJsonDocument(request).toJson(QJsonDocument::Compact));
+				documentLog.write("\n");
+				documentLog.flush();
+			}
+			if (definitionMode == QStringLiteral("delayed"))
+				QThread::msleep(200);
+			if (definitionMode == QStringLiteral("error")) {
+				const QJsonObject response = jsonObject({
+					{QStringLiteral("jsonrpc"), QStringLiteral("2.0")},
+					{QStringLiteral("id"), request.value(QStringLiteral("id"))},
+					{QStringLiteral("error"), jsonObject({{QStringLiteral("code"), -32001}, {QStringLiteral("message"), QStringLiteral("scripted definition failure")}})}
+				});
+				if (!writeAll(output, frame(response)))
+					return 3;
+				continue;
+			}
+			const QJsonObject position = positionValue.toObject();
+			QJsonObject end = position;
+			end.insert(QStringLiteral("character"), position.value(QStringLiteral("character")).toInt() + 1);
+			const QJsonObject range = jsonObject({{QStringLiteral("start"), position}, {QStringLiteral("end"), end}});
+			const QString uri = definitionMode == QStringLiteral("nonfile")
+			                  ? QStringLiteral("untitled:definition")
+			                  : definitionTarget.isEmpty() ? document.value(QStringLiteral("uri")).toString() : definitionTarget;
+			const QJsonObject location = jsonObject({{QStringLiteral("uri"), uri}, {QStringLiteral("range"), range}});
+			QJsonValue result;
+			if (definitionMode == QStringLiteral("null"))
+				result = QJsonValue(QJsonValue::Null);
+			else if (definitionMode == QStringLiteral("array"))
+				result = jsonArray({location, location});
+			else if (definitionMode == QStringLiteral("link"))
+				result = jsonArray({jsonObject({{QStringLiteral("targetUri"), uri},
+				                                {QStringLiteral("targetRange"), range},
+				                                {QStringLiteral("targetSelectionRange"), range}})});
+			else if (definitionMode == QStringLiteral("malformed"))
+				result = jsonObject({{QStringLiteral("uri"), uri}, {QStringLiteral("range"), QStringLiteral("bad")}});
+			else
+				result = location;
+			const QJsonObject response = jsonObject({
+				{QStringLiteral("jsonrpc"), QStringLiteral("2.0")},
+				{QStringLiteral("id"), request.value(QStringLiteral("id"))},
+				{QStringLiteral("result"), result}
+			});
+			if (!writeAll(output, frame(response)))
+				return 3;
+			continue;
+		}
+		if (method == QStringLiteral("textDocument/completion")) {
+			const QJsonObject params = request.value(QStringLiteral("params")).toObject();
+			const QJsonObject document = params.value(QStringLiteral("textDocument")).toObject();
+			const QJsonValue positionValue = params.value(QStringLiteral("position"));
+			if (!initializedObserved || !document.value(QStringLiteral("uri")).isString()
+			    || !validPosition(positionValue))
+				return 7;
+			if (documentLog.isOpen()) {
+				documentLog.write(QJsonDocument(request).toJson(QJsonDocument::Compact));
+				documentLog.write("\n");
+				documentLog.flush();
+			}
+			if (completionMode == QStringLiteral("delayed")
+			    || completionMode.startsWith(QStringLiteral("after-"))
+			    || completionMode == QStringLiteral("superseded"))
+				QThread::msleep(200);
+			if (completionMode == QStringLiteral("error")
+			    || completionMode == QStringLiteral("after-service-failure")) {
+				const QJsonObject response = jsonObject({
+					{QStringLiteral("jsonrpc"), QStringLiteral("2.0")},
+					{QStringLiteral("id"), request.value(QStringLiteral("id"))},
+					{QStringLiteral("error"), jsonObject({{QStringLiteral("code"), -32001}, {QStringLiteral("message"), QStringLiteral("scripted completion failure")}})}
+				});
+				if (!writeAll(output, frame(response)))
+					return 3;
+				continue;
+			}
+			const QJsonObject start = jsonObject({{QStringLiteral("line"), positionValue.toObject().value(QStringLiteral("line"))},
+		                                         {QStringLiteral("character"), qMax(0, positionValue.toObject().value(QStringLiteral("character")).toInt() - 2)}});
+			const QJsonObject range = jsonObject({{QStringLiteral("start"), start}, {QStringLiteral("end"), positionValue}});
+			QJsonValue result;
+			if (completionMode == QStringLiteral("null")) {
+				result = QJsonValue(QJsonValue::Null);
+			}
+			else if (completionMode == QStringLiteral("malformed")) {
+				result = QStringLiteral("bad");
+			}
+			else {
+				QJsonArray items;
+				if (completionMode == QStringLiteral("label"))
+					items.append(jsonObject({{QStringLiteral("label"), QStringLiteral("providerLabel")}}));
+				else if (completionMode == QStringLiteral("insert"))
+					items.append(jsonObject({{QStringLiteral("label"), QStringLiteral("providerLabel")}, {QStringLiteral("insertText"), QStringLiteral("providerInsert")}}));
+				else if (completionMode == QStringLiteral("textedit") || completionMode == QStringLiteral("utf16-range"))
+					items.append(jsonObject({{QStringLiteral("label"), QStringLiteral("providerEdit")},
+					                         {QStringLiteral("textEdit"), jsonObject({{QStringLiteral("range"), range}, {QStringLiteral("newText"), QStringLiteral("providerEdit")}})}}));
+				else if (completionMode == QStringLiteral("metadata"))
+					items.append(jsonObject({{QStringLiteral("label"), QStringLiteral("providerMeta")},
+					                         {QStringLiteral("detail"), QStringLiteral("detail")},
+					                         {QStringLiteral("documentation"), jsonObject({{QStringLiteral("kind"), QStringLiteral("markdown")}, {QStringLiteral("value"), QStringLiteral("documentation")}})}}));
+				else if (completionMode == QStringLiteral("snippet"))
+					items.append(jsonObject({{QStringLiteral("label"), QStringLiteral("snippet")}, {QStringLiteral("insertText"), QStringLiteral("${1:value}")}, {QStringLiteral("insertTextFormat"), 2}}));
+				else if (completionMode == QStringLiteral("malformed-item"))
+					items.append(jsonObject({{QStringLiteral("label"), 17}, {QStringLiteral("textEdit"), QStringLiteral("bad")}}));
+				else if (completionMode == QStringLiteral("invalid-range"))
+					items.append(jsonObject({
+						{QStringLiteral("label"), QStringLiteral("invalid")},
+						{QStringLiteral("textEdit"), jsonObject({
+							{QStringLiteral("range"), jsonObject({
+								{QStringLiteral("start"), jsonObject({
+									{QStringLiteral("line"), -1},
+									{QStringLiteral("character"), 0}
+								})},
+								{QStringLiteral("end"), positionValue}
+							})},
+							{QStringLiteral("newText"), QStringLiteral("invalid")}
+						})}
+					}));
+				else if (completionMode == QStringLiteral("duplicate"))
+					items.append(jsonObject({{QStringLiteral("label"), QStringLiteral("adlen")}, {QStringLiteral("insertText"), QString::fromUtf8("\\addtolength{}{\u2022}\n")}}));
+				else
+					items = jsonArray({jsonObject({{QStringLiteral("label"), QStringLiteral("providerLabel")}}),
+					                   jsonObject({{QStringLiteral("label"), QStringLiteral("providerInsert")}, {QStringLiteral("insertText"), QStringLiteral("inserted")}})});
+				result = completionMode == QStringLiteral("list")
+				       ? QJsonValue(jsonObject({{QStringLiteral("isIncomplete"), true}, {QStringLiteral("items"), items}}))
+				       : QJsonValue(items);
+			}
+			const QJsonObject response = jsonObject({{QStringLiteral("jsonrpc"), QStringLiteral("2.0")},
+			                           {QStringLiteral("id"), request.value(QStringLiteral("id"))},
+			                           {QStringLiteral("result"), result}});
+			if (!writeAll(output, frame(response)))
+				return 3;
 			continue;
 		}
 		if (!lspProfile.isEmpty() && method == QStringLiteral("shutdown")) {

--- a/unit-tests/language_server_fake.cpp
+++ b/unit-tests/language_server_fake.cpp
@@ -1,0 +1,358 @@
+/*
+	This is part of TeXworks, an environment for working with TeX documents
+	Copyright (C) 2026  TeXworks contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+	For links to further information, or to contact the authors,
+	see <https://tug.org/texworks/>.
+*/
+
+#include <QCoreApplication>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QPair>
+#include <QStringList>
+#include <QThread>
+
+#include <cstdlib>
+#include <initializer_list>
+
+namespace {
+
+QJsonObject jsonObject(const std::initializer_list<QPair<QString, QJsonValue>> & values)
+{
+	QJsonObject object;
+	for (const QPair<QString, QJsonValue> & value : values)
+		object.insert(value.first, value.second);
+	return object;
+}
+
+QJsonArray jsonArray(const std::initializer_list<QJsonValue> & values)
+{
+	QJsonArray array;
+	for (const QJsonValue & value : values)
+		array.append(value);
+	return array;
+}
+
+QByteArray frame(const QJsonObject & message)
+{
+	const QByteArray body = QJsonDocument(message).toJson(QJsonDocument::Compact);
+	return QByteArrayLiteral("Content-Length: ") + QByteArray::number(body.size()) + QByteArrayLiteral("\r\n\r\n") + body;
+}
+
+bool writeAll(QFile & output, const QByteArray & data)
+{
+	qint64 offset = 0;
+	while (offset < data.size()) {
+		const qint64 written = output.write(data.constData() + offset, data.size() - offset);
+		if (written <= 0)
+			return false;
+		offset += written;
+	}
+	return output.flush();
+}
+
+bool readMessage(QFile & input, QJsonObject & message)
+{
+	qint64 contentLength = -1;
+	while (true) {
+		const QByteArray line = input.readLine();
+		if (line.isEmpty())
+			return false;
+		if (line == QByteArrayLiteral("\r\n"))
+			break;
+		const auto colon = line.indexOf(':');
+		if (colon > 0 && line.left(colon).trimmed().toLower() == QByteArrayLiteral("content-length"))
+			contentLength = line.mid(colon + 1).trimmed().toLongLong();
+	}
+	if (contentLength < 0)
+		return false;
+
+	QByteArray body;
+	while (body.size() < contentLength) {
+		const QByteArray chunk = input.read(contentLength - body.size());
+		if (chunk.isEmpty())
+			return false;
+		body.append(chunk);
+	}
+	const QJsonDocument document = QJsonDocument::fromJson(body);
+	if (!document.isObject())
+		return false;
+	message = document.object();
+	return true;
+}
+
+QJsonObject initializeCapabilities(const QString & profile)
+{
+	QJsonObject capabilities;
+	if (profile == QStringLiteral("digestif") || profile == QStringLiteral("unknown")) {
+		capabilities = jsonObject({
+			{QStringLiteral("positionEncoding"), QStringLiteral("utf-16")},
+			{QStringLiteral("textDocumentSync"), jsonObject({{QStringLiteral("openClose"), true}, {QStringLiteral("change"), 2}})},
+			{QStringLiteral("completionProvider"), QJsonObject{}},
+			{QStringLiteral("signatureHelpProvider"), QJsonObject{}},
+			{QStringLiteral("hoverProvider"), true},
+			{QStringLiteral("definitionProvider"), true},
+			{QStringLiteral("referencesProvider"), true},
+			{QStringLiteral("documentSymbolProvider"), true},
+			{QStringLiteral("workspaceSymbolProvider"), true}
+		});
+		if (profile == QStringLiteral("unknown"))
+			capabilities.insert(QStringLiteral("experimentalProviderThing"), jsonObject({{QStringLiteral("future"), true}}));
+	}
+	else if (profile == QStringLiteral("numeric-incremental")) {
+		capabilities.insert(QStringLiteral("textDocumentSync"), 2);
+	}
+	else if (profile == QStringLiteral("full")) {
+		capabilities.insert(QStringLiteral("textDocumentSync"), 1);
+	}
+	else if (profile == QStringLiteral("none")) {
+		capabilities.insert(QStringLiteral("textDocumentSync"), 0);
+	}
+	else if (profile == QStringLiteral("open-close-false")) {
+		capabilities.insert(QStringLiteral("textDocumentSync"), jsonObject({{QStringLiteral("openClose"), false}, {QStringLiteral("change"), 2}}));
+	}
+	else if (profile == QStringLiteral("open-close-absent")) {
+		capabilities.insert(QStringLiteral("textDocumentSync"), jsonObject({{QStringLiteral("change"), 2}}));
+	}
+	else if (profile == QStringLiteral("features-false")) {
+		capabilities = jsonObject({
+			{QStringLiteral("completionProvider"), false},
+			{QStringLiteral("signatureHelpProvider"), false},
+			{QStringLiteral("hoverProvider"), false},
+			{QStringLiteral("definitionProvider"), false},
+			{QStringLiteral("referencesProvider"), false},
+			{QStringLiteral("documentSymbolProvider"), false},
+			{QStringLiteral("workspaceSymbolProvider"), false}
+		});
+	}
+	else if (profile == QStringLiteral("invalid-sync")) {
+		capabilities.insert(QStringLiteral("textDocumentSync"), QStringLiteral("incremental"));
+	}
+	if (profile == QStringLiteral("utf8"))
+		capabilities.insert(QStringLiteral("positionEncoding"), QStringLiteral("utf-8"));
+	else if (profile == QStringLiteral("utf32"))
+		capabilities.insert(QStringLiteral("positionEncoding"), QStringLiteral("utf-32"));
+	return capabilities;
+}
+
+bool validInitializeRequest(const QJsonObject & request)
+{
+	const QJsonObject params = request.value(QStringLiteral("params")).toObject();
+	const QJsonArray encodings = params.value(QStringLiteral("capabilities")).toObject()
+	                               .value(QStringLiteral("general")).toObject()
+	                               .value(QStringLiteral("positionEncodings")).toArray();
+	return params.value(QStringLiteral("processId")).isDouble()
+	       && params.contains(QStringLiteral("rootUri")) && params.value(QStringLiteral("rootUri")).isNull()
+	       && encodings == jsonArray({QStringLiteral("utf-16")})
+	       && !params.value(QStringLiteral("capabilities")).toObject().contains(QStringLiteral("textDocument"));
+}
+
+bool isUnsupportedRequestRejection(const QJsonObject & response)
+{
+	const QJsonObject error = response.value(QStringLiteral("error")).toObject();
+	return response.value(QStringLiteral("jsonrpc")) == QJsonValue(QStringLiteral("2.0"))
+	       && response.value(QStringLiteral("id")) == QJsonValue(QStringLiteral("server-request-id"))
+	       && response.value(QStringLiteral("error")).isObject()
+	       && error.value(QStringLiteral("code")) == QJsonValue(-32601)
+	       && error.value(QStringLiteral("message")).isString()
+	       && !error.value(QStringLiteral("message")).toString().isEmpty()
+	       && !response.contains(QStringLiteral("result"))
+	       && !response.contains(QStringLiteral("method"))
+	       && !response.contains(QStringLiteral("params"));
+}
+
+} // namespace
+
+int main(int argc, char * argv[])
+{
+	QCoreApplication app(argc, argv);
+	const QStringList arguments = app.arguments();
+	const auto profileIndex = arguments.indexOf(QStringLiteral("--lsp-profile"));
+	const QString lspProfile = profileIndex >= 0 && profileIndex + 1 < arguments.size()
+	                         ? arguments.at(profileIndex + 1) : QString{};
+	const auto confirmationLogIndex = arguments.indexOf(QStringLiteral("--confirmation-log"));
+	const QString confirmationLogPath = confirmationLogIndex >= 0 && confirmationLogIndex + 1 < arguments.size()
+	                                  ? arguments.at(confirmationLogIndex + 1) : QString{};
+	if (arguments.contains(QStringLiteral("--exit-normal")))
+		return 0;
+	if (arguments.contains(QStringLiteral("--crash")))
+		std::abort();
+	if (arguments.contains(QStringLiteral("--idle"))) {
+		while (true)
+			QThread::msleep(100);
+	}
+
+	QFile input;
+	QFile output;
+	QFile error;
+	if (!input.open(stdin, QIODevice::ReadOnly) || !output.open(stdout, QIODevice::WriteOnly)
+	    || !error.open(stderr, QIODevice::WriteOnly))
+		return 2;
+	QFile confirmationLog(confirmationLogPath);
+	if (!confirmationLogPath.isEmpty() && !confirmationLog.open(QIODevice::WriteOnly | QIODevice::Append))
+		return 2;
+
+	QJsonObject request;
+	bool initializedObserved = false;
+	bool unsupportedRequestPending = false;
+	bool unsupportedRequestRejected = false;
+	while (readMessage(input, request)) {
+		if (lspProfile == QStringLiteral("unsupported-request") && unsupportedRequestPending
+		    && request.value(QStringLiteral("id")) == QJsonValue(QStringLiteral("server-request-id"))) {
+			if (!isUnsupportedRequestRejection(request))
+				return 8;
+			unsupportedRequestPending = false;
+			unsupportedRequestRejected = true;
+			if (!writeAll(confirmationLog, QByteArrayLiteral("unsupported request rejected\n")))
+				return 3;
+			continue;
+		}
+		const QString method = request.value(QStringLiteral("method")).toString();
+		if (!lspProfile.isEmpty() && method == QStringLiteral("initialize")) {
+			if (lspProfile == QStringLiteral("initialize-exit"))
+				return 0;
+			if (lspProfile == QStringLiteral("delayed-initialize"))
+				QThread::msleep(300);
+			if (!validInitializeRequest(request)) {
+				const QJsonObject errorResponse = jsonObject({
+					{QStringLiteral("jsonrpc"), QStringLiteral("2.0")},
+					{QStringLiteral("id"), request.value(QStringLiteral("id"))},
+					{QStringLiteral("error"), jsonObject({{QStringLiteral("code"), -32602}, {QStringLiteral("message"), QStringLiteral("invalid initialize shape")}})}
+				});
+				if (!writeAll(output, frame(errorResponse)))
+					return 3;
+				continue;
+			}
+			if (lspProfile == QStringLiteral("initialize-error")) {
+				const QJsonObject errorResponse = jsonObject({
+					{QStringLiteral("jsonrpc"), QStringLiteral("2.0")},
+					{QStringLiteral("id"), request.value(QStringLiteral("id"))},
+					{QStringLiteral("error"), jsonObject({{QStringLiteral("code"), -32002}, {QStringLiteral("message"), QStringLiteral("scripted initialize failure")}})}
+				});
+				if (!writeAll(output, frame(errorResponse)))
+					return 3;
+				continue;
+			}
+			const QJsonValue result = lspProfile == QStringLiteral("malformed-initialize")
+			                        ? QJsonValue(QJsonArray{})
+			                        : QJsonValue(jsonObject({{QStringLiteral("capabilities"), initializeCapabilities(lspProfile)}}));
+			const QJsonObject response = jsonObject({
+				{QStringLiteral("jsonrpc"), QStringLiteral("2.0")},
+				{QStringLiteral("id"), request.value(QStringLiteral("id"))},
+				{QStringLiteral("result"), result}
+			});
+			if (!writeAll(output, frame(response)))
+				return 3;
+			continue;
+		}
+		if (!lspProfile.isEmpty() && method == QStringLiteral("initialized")) {
+			initializedObserved = true;
+			if (lspProfile == QStringLiteral("exit-after-initialized"))
+				return 0;
+			const QJsonObject observed = jsonObject({
+				{QStringLiteral("jsonrpc"), QStringLiteral("2.0")},
+				{QStringLiteral("method"), QStringLiteral("fake/initializedObserved")}
+			});
+			if (!writeAll(output, frame(observed)))
+				return 3;
+			if (lspProfile == QStringLiteral("unsupported-request")) {
+				const QJsonObject unsupportedRequest = jsonObject({
+					{QStringLiteral("jsonrpc"), QStringLiteral("2.0")},
+					{QStringLiteral("id"), QStringLiteral("server-request-id")},
+					{QStringLiteral("method"), QStringLiteral("fake/unsupportedRequest")}
+				});
+				if (!writeAll(output, frame(unsupportedRequest)))
+					return 3;
+				unsupportedRequestPending = true;
+			}
+			continue;
+		}
+		if (!lspProfile.isEmpty() && method == QStringLiteral("shutdown")) {
+			if (!initializedObserved || (lspProfile == QStringLiteral("unsupported-request") && !unsupportedRequestRejected))
+				return 4;
+			if (lspProfile == QStringLiteral("shutdown-timeout"))
+				continue;
+			const QJsonObject response = jsonObject({
+				{QStringLiteral("jsonrpc"), QStringLiteral("2.0")},
+				{QStringLiteral("id"), request.value(QStringLiteral("id"))},
+				{QStringLiteral("result"), QJsonValue(QJsonValue::Null)}
+			});
+			if (!writeAll(output, frame(response)))
+				return 3;
+			continue;
+		}
+		if (!lspProfile.isEmpty() && method == QStringLiteral("exit")) {
+			error.write("fake-server exit received\n");
+			error.flush();
+			return 0;
+		}
+		if (method == QStringLiteral("noResponse"))
+			continue;
+		if (method == QStringLiteral("exitNormal"))
+			return 0;
+		if (method == QStringLiteral("crash"))
+			std::abort();
+		if (method == QStringLiteral("malformed")) {
+			if (!writeAll(output, QByteArrayLiteral("Content-Length: invalid\r\n\r\n")))
+				return 3;
+			continue;
+		}
+		if (method == QStringLiteral("delay"))
+			QThread::msleep(100);
+		if (method == QStringLiteral("stderr")) {
+			error.write("fake-server stderr\n");
+			error.flush();
+		}
+
+		QJsonObject response = jsonObject({
+			{QStringLiteral("jsonrpc"), QStringLiteral("2.0")},
+			{QStringLiteral("id"), request.value(QStringLiteral("id"))},
+			{QStringLiteral("result"), request.value(QStringLiteral("params"))}
+		});
+		QByteArray outputBytes = frame(response);
+		if (method == QStringLiteral("several")) {
+			const QJsonObject notification = jsonObject({
+				{QStringLiteral("jsonrpc"), QStringLiteral("2.0")},
+				{QStringLiteral("method"), QStringLiteral("fake/notification")},
+				{QStringLiteral("params"), jsonObject({{QStringLiteral("source"), QStringLiteral("fake")}})}
+			});
+			outputBytes.prepend(frame(notification));
+		}
+
+		if (method == QStringLiteral("fragmentHeader")) {
+			if (!writeAll(output, outputBytes.left(8)))
+				return 3;
+			QThread::msleep(20);
+			if (!writeAll(output, outputBytes.mid(8)))
+				return 3;
+		}
+		else if (method == QStringLiteral("fragmentBody")) {
+			const auto split = outputBytes.indexOf("\r\n\r\n") + 6;
+			if (!writeAll(output, outputBytes.left(split)))
+				return 3;
+			QThread::msleep(20);
+			if (!writeAll(output, outputBytes.mid(split)))
+				return 3;
+		}
+		else if (!writeAll(output, outputBytes)) {
+			return 3;
+		}
+	}
+	return 0;
+}


### PR DESCRIPTION
## Summary

Add optional language-server assistance for ConTeXt/LMTX documents, including
completion and Go to Definition, together with modern ConTeXt/LuaMetaTeX
defaults and documentation. No external provider dependency is introduced.

## Motivation

ConTeXt/LMTX users can benefit from language-service assistance without making
an external provider a TeXworks dependency or changing the normal editor and
typesetting workflow.

## What this changes

* Adds .mkiv/.mkxl recognition and modern ConTeXt (LuaMetaTeX) defaults while
  retaining the distinct LuaTeX engine.
* Adds optional asynchronous provider completion that augments native/static
  completion.
* Adds capability-gated Go to Definition, with safe local same-file and
  cross-file navigation for one usable local-file result.
* Adds disabled-by-default Preferences configuration for an external provider.
  Each argument is one literal line and is passed separately, with no shell
  parsing.

## Architecture

The public generic LanguageService API, manager, document binding, and types
are provider-neutral. The manager owns active/pending service replacement and
document-binding authority; bindings own synchronization, generations,
freshness, and request tokens; process and JSON-RPC remain in the external
adapter; and editor/window code consumes capability-gated results. The adapter
implements a limited LSP subset; this is not a claim of universal LSP support.

## ConTeXt and Digestif

Language-server support is optional and disabled by default. TeXworks does not
bundle, install, or discover a provider. Digestif is a tested ConTeXt/LMTX
example only, not a dependency or a promise of support for every provider.

Optional real-provider validation was reproduced against [Digestif validation
revision `38aa19c0f11da9d1f08c24ec19724f11060b897f`](https://github.com/slem567/digestif/tree/38aa19c0f11da9d1f08c24ec19724f11060b897f),
published in `slem567/digestif` on branch `validation/texworks-context-lmtx`.
That revision contains the ConTeXt/LSP fixes used for the test, including modern
project/component filename resolution. It is a validation input only; TeXworks
does not bundle or require Digestif and its language-service API remains
provider-neutral.

## Compatibility

Normal TeXworks editing remains available without a provider or when one is
unavailable, including native/static completion. The project policy floor
remains Qt 5.2.3. The actual Trusty Qt 5.2.1 proof is compatibility evidence;
it does not change that policy.

## Validation

These are local validation results:

* Qt 6: full configured CTest 13/13 passed.
* Ubuntu Trusty / Qt 5.2.1: full configured CTest 13/13 passed.
* Public Digestif validation revision 38aa19c0: both TeXworks real-provider
  layers passed (3/3 each).
* Manual smoke: startup, main.mkxl, PDF preview, local/cross-file F12,
  truthful availability status, and clean shutdown.

## Commit structure

The five commits are ordered for review:

1. 88a18ff9 — ConTeXt metadata/defaults
2. 965ad582 — provider-neutral service foundation
3. 82ec5f73 — document/editor completion and definition integration
4. 599ace82 — optional Preferences/configuration
5. f05cb9cb — documentation

Each behavior layer includes its associated tests.

## Translation handling

This series adds translatable source strings but intentionally omits translation
catalog churn. TeXworks uses Weblate, and generated .qm files are not part of
this submission. Please advise whether a Weblate refresh should follow.
